### PR TITLE
fix(client): fix voprf proof always verifying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+node_modules
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 lib
+coverage

--- a/examples/poprf.ts
+++ b/examples/poprf.ts
@@ -42,7 +42,7 @@ export async function poprfExample() {
     // the client with an evaluation.
     //
     //          evaluation = BlindEvaluate(evalReq, info*)
-    const evaluation = await server.blindEvaluate(evalReq)
+    const evaluation = await server.blindEvaluate(evalReq, infoBytes)
     //            evaluation
     //       <<------------------
     //

--- a/src/client.ts
+++ b/src/client.ts
@@ -127,7 +127,7 @@ export class POPRFClient extends baseClient {
         }
 
         if (
-            !evaluation.proof.verify_batch(
+            !await evaluation.proof.verify_batch(
                 [this.gg.generator(), tw],
                 zip(evaluation.evaluated, finData.evalReq.blinded)
             )

--- a/src/client.ts
+++ b/src/client.ts
@@ -84,10 +84,10 @@ export class VOPRFClient extends baseClient {
         }
 
         if (
-            !await evaluation.proof.verify_batch(
+            !(await evaluation.proof.verify_batch(
                 [this.gg.generator(), pkS],
                 zip(finData.evalReq.blinded, evaluation.evaluated)
-            )
+            ))
         ) {
             throw new Error('proof failed')
         }
@@ -127,10 +127,10 @@ export class POPRFClient extends baseClient {
         }
 
         if (
-            !await evaluation.proof.verify_batch(
+            !(await evaluation.proof.verify_batch(
                 [this.gg.generator(), tw],
                 zip(evaluation.evaluated, finData.evalReq.blinded)
-            )
+            ))
         ) {
             throw new Error('proof failed')
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,7 +72,7 @@ export class VOPRFClient extends baseClient {
         super(Oprf.Mode.VOPRF, suite)
     }
 
-    finalize(finData: FinalizeData, evaluation: Evaluation): Promise<Array<Uint8Array>> {
+    async finalize(finData: FinalizeData, evaluation: Evaluation): Promise<Array<Uint8Array>> {
         if (!evaluation.proof) {
             throw new Error('no proof provided')
         }
@@ -84,7 +84,7 @@ export class VOPRFClient extends baseClient {
         }
 
         if (
-            !evaluation.proof.verify_batch(
+            !await evaluation.proof.verify_batch(
                 [this.gg.generator(), pkS],
                 zip(finData.evalReq.blinded, evaluation.evaluated)
             )

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -29,7 +29,6 @@ async function testBadProof(
     const badEval = Evaluation.deserialize(server.constructDLEQParams(), evaluation.serialize())
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     Object.assign(badEval.proof!, { s: evaluation.proof!.c })
-    // eslint-disable-next-line jest/no-conditional-expect
     await expect(client.finalize(finData, badEval)).rejects.toThrow(/proof failed/)
 }
 

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -75,7 +75,6 @@ describe.each(Object.entries(Oprf.Mode))('protocol', (modeName, mode) => {
             // Client
             // output = Finalize(finData, evaluation, info*)
             //
-
             const output = await client.finalize(finData, evaluation)
             expect(output[0]).toHaveLength(Oprf.getOprfSize(id))
 

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -20,10 +20,15 @@ import {
 
 import { serdeClass } from './util.js'
 
-async function testBadProof(client: OPRFClient, server: OPRFServer, finData: FinalizeData, evaluation: Evaluation) {
+async function testBadProof(
+    client: OPRFClient,
+    server: OPRFServer,
+    finData: FinalizeData,
+    evaluation: Evaluation
+) {
     const badEval = Evaluation.deserialize(server.constructDLEQParams(), evaluation.serialize())
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    Object.assign(badEval.proof!, {s: evaluation.proof!.c})
+    Object.assign(badEval.proof!, { s: evaluation.proof!.c })
     // eslint-disable-next-line jest/no-conditional-expect
     await expect(client.finalize(finData, badEval)).rejects.toThrow(/proof failed/)
 }

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -25,9 +25,7 @@ async function testBadProof(client: OPRFClient, server: OPRFServer, finData: Fin
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     Object.assign(badEval.proof!, {s: evaluation.proof!.c})
     // eslint-disable-next-line jest/no-conditional-expect
-    await expect(async () => {
-        await client.finalize(finData, badEval)
-    }).rejects.toThrow()
+    await expect(client.finalize(finData, badEval)).rejects.toThrow(/proof failed/)
 }
 
 describe.each(Object.entries(Oprf.Mode))('protocol', (modeName, mode) => {


### PR DESCRIPTION
```typescript
        if ( // VVVVV ooops
            !evaluation.proof.verify_batch(
                [this.gg.generator(), pkS],
                zip(finData.evalReq.blinded, evaluation.evaluated)
            )
        ) {
            throw new Error('proof failed')
        }
```

A promise will always evaluate as truthy so the check would always verify regardless of whether proof was valid

Upon fixing that discovered a bug in the example:
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/525211/236784326-a53e7914-9ae6-48b7-b8cb-0a851cc48278.png">

TODO:
- [x] Add an actual test for when a proof is invalid (e.g. signed with a different key)
