### PR TITLE
feat(group): make Oprf.Group pluggable

### DIFF
--- a/bench/group.bench.ts
+++ b/bench/group.bench.ts
@@ -4,7 +4,7 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import Benchmark from 'benchmark'
-import { Group } from '../src/index.js'
+import { Oprf } from '../src/index.js'
 
 function asyncFn(call: CallableFunction) {
     return {
@@ -21,8 +21,8 @@ export async function benchGroup(bs: Benchmark.Suite) {
     const msg = te.encode('msg')
     const dst = te.encode('dst')
 
-    for (const id of Object.values(Group.ID)) {
-        const gg = new Group(id)
+    for (const id of Object.values(Oprf.Group.ID)) {
+        const gg = new Oprf.Group(id)
         const k = await gg.randomScalar()
         const P = gg.mulGen(k)
         const Q = P.mul(k)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "@cloudflare/voprf-ts",
             "version": "0.21.0",
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "sjcl": "1.0.8"
-            },
             "devDependencies": {
                 "@types/benchmark": "2.1.2",
                 "@types/jest": "29.2.3",
@@ -25,6 +22,7 @@
                 "eslint-plugin-security": "1.5.0",
                 "jest": "29.3.1",
                 "prettier": "2.7.1",
+                "sjcl": "1.0.8",
                 "typescript": "4.8.4"
             },
             "engines": {
@@ -4358,6 +4356,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
             "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -8018,7 +8017,8 @@
         "sjcl": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-            "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
+            "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+            "dev": true
         },
         "slash": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "eslint-plugin-security": "1.5.0",
         "jest": "29.3.1",
         "prettier": "2.7.1",
-        "typescript": "4.8.4"
+        "typescript": "4.8.4",
+        "sjcl": "1.0.8"
     },
     "scripts": {
         "prepack": "tsc -b",
@@ -52,8 +53,5 @@
         "lint": "eslint .",
         "bench": "tsc -b bench && node ./lib/bench/index.js",
         "format": "prettier './(src|test|bench|examples)/*.ts' --write"
-    },
-    "dependencies": {
-        "sjcl": "1.0.8"
     }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { Elt, Scalar } from './group.js'
+import { Elt, Scalar } from './groupTypes.js'
 import { Evaluation, EvaluationRequest, FinalizeData, ModeID, Oprf, SuiteID } from './oprf.js'
 
 import { zip } from './util.js'
@@ -76,7 +76,7 @@ export class VOPRFClient extends baseClient {
         if (!evaluation.proof) {
             throw new Error('no proof provided')
         }
-        const pkS = Elt.deserialize(this.gg, this.pubKeyServer)
+        const pkS = this.gg.desElt(this.pubKeyServer)
 
         const n = finData.inputs.length
         if (evaluation.evaluated.length !== n) {
@@ -104,7 +104,7 @@ export class POPRFClient extends baseClient {
     private async pointFromInfo(info: Uint8Array): Promise<Elt> {
         const m = await this.scalarFromInfo(info)
         const T = this.gg.mulGen(m)
-        const pkS = Elt.deserialize(this.gg, this.pubKeyServer)
+        const pkS = this.gg.desElt(this.pubKeyServer)
         const tw = pkS.add(T)
         if (tw.isIdentity()) {
             throw new Error('invalid info')

--- a/src/dleq.ts
+++ b/src/dleq.ts
@@ -5,7 +5,7 @@
 //
 // Implementation of batched discrete log equivalents proofs (DLEQ) as
 // described in https://www.ietf.org/id/draft-irtf-cfrg-voprf-09.html#name-discrete-log-equivalence-pr.
-import { Elt, Group, Scalar } from './group.js'
+import { Elt, Group, Scalar } from './groupTypes.js'
 import { checkSize, joinAll, to16bits, toU16LenPrefix } from './util.js'
 
 export interface DLEQParams {
@@ -121,14 +121,15 @@ export class DLEQProof {
     }
 
     static size(params: DLEQParams): number {
-        return 2 * Scalar.size(params.gg)
+        return 2 * params.gg.scalarSize()
     }
 
     static deserialize(params: Required<DLEQParams>, bytes: Uint8Array): DLEQProof {
         checkSize(bytes, DLEQProof, params)
-        const n = Scalar.size(params.gg)
-        const c = Scalar.deserialize(params.gg, bytes.subarray(0, n))
-        const s = Scalar.deserialize(params.gg, bytes.subarray(n, 2 * n))
+        const group = params.gg
+        const n = group.scalarSize()
+        const c = group.desScalar(bytes.subarray(0, n))
+        const s = group.desScalar(bytes.subarray(n, 2 * n))
         return new DLEQProof(params, c, s)
     }
 }

--- a/src/groupTypes.ts
+++ b/src/groupTypes.ts
@@ -1,0 +1,110 @@
+export const GroupIDs = {
+    P256: 'P-256',
+    P384: 'P-384',
+    P521: 'P-521'
+} as const
+
+export type GroupID = typeof GroupIDs[keyof typeof GroupIDs]
+
+export function errBadGroup(X: string) {
+    return new Error(`group: bad group name ${X}.`)
+}
+
+export function getGroupID(id: string): GroupID {
+    switch (id) {
+        case 'P-256':
+            return GroupIDs.P256
+        case 'P-384':
+            return GroupIDs.P384
+        case 'P-521':
+            return GroupIDs.P521
+        default:
+            throw errBadGroup(id)
+    }
+}
+
+export interface Scalar {
+    g: Group
+
+    isEqual(s: Scalar): boolean
+
+    isZero(): boolean
+
+    add(s: Scalar): Scalar
+
+    sub(s: Scalar): Scalar
+
+    mul(s: Scalar): Scalar
+
+    inv(): Scalar
+
+    serialize(): Uint8Array
+}
+
+export interface ScalarCons {
+    size(g: Group): number
+    deserialize(g: Group, bytes: Uint8Array): Scalar
+}
+
+export interface Elt {
+    g: Group
+
+    isIdentity(): boolean
+
+    isEqual(a: Elt): boolean
+
+    neg(): Elt
+
+    add(a: Elt): Elt
+
+    mul(s: Scalar): Elt
+
+    mul2(k1: Scalar, a: Elt, k2: Scalar): Elt
+
+    serialize(compressed?: boolean): Uint8Array
+}
+
+export interface EltCons {
+    // Used by serializer
+    size(g: Group, compressed?: boolean): number
+    deserialize(g: Group, bytes: Uint8Array): Elt
+}
+
+export interface Deserializer<T> {
+    size(compressed?: boolean): number
+
+    deserialize(b: Uint8Array): T
+}
+
+export interface SerializationHelpers {
+    desElt(bytes: Uint8Array): Elt
+    desScalar(bytes: Uint8Array): Scalar
+
+    eltDes: Deserializer<Elt>
+    scalarDes: Deserializer<Scalar>
+
+    eltSize(compressed?: boolean): number
+    scalarSize(): number
+}
+
+export interface Group extends SerializationHelpers {
+    id: GroupID
+    size: number
+
+    newScalar(): Scalar
+    newElt(): Elt
+    identity(): Elt
+    generator(): Elt
+    mulGen(s: Scalar): Elt
+    randomScalar(): Promise<Scalar>
+    hashToGroup(msg: Uint8Array, dst: Uint8Array): Promise<Elt>
+    hashToScalar(msg: Uint8Array, dst: Uint8Array): Promise<Scalar>
+}
+
+export interface GroupCons {
+    new (id: GroupID): Group
+    ID: typeof GroupIDs
+    getID: typeof getGroupID
+    Elt: EltCons
+    Scalar: ScalarCons
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,12 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-export * from './group.js'
+import { GroupConsSjcl } from './groupSjcl.js'
+import { Oprf } from './oprf.js'
+
+Oprf.Group = GroupConsSjcl
+
+export * from './groupTypes.js'
 export * from './dleq.js'
 export * from './oprf.js'
 export * from './client.js'

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -3,9 +3,9 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { Elt, Scalar } from './group.js'
 import { ModeID, Oprf, SuiteID } from './oprf.js'
 import { joinAll, toU16LenPrefix } from './util.js'
+import { Scalar } from './groupTypes.js'
 
 export function getKeySizes(id: SuiteID): { Nsk: number; Npk: number } {
     const gg = Oprf.getGroup(id)
@@ -14,7 +14,7 @@ export function getKeySizes(id: SuiteID): { Nsk: number; Npk: number } {
 
 export function validatePrivateKey(id: SuiteID, privateKey: Uint8Array): boolean {
     try {
-        const s = Scalar.deserialize(Oprf.getGroup(id), privateKey)
+        const s = Oprf.getGroup(id).desScalar(privateKey)
         return !s.isZero()
     } catch (_) {
         return false
@@ -23,7 +23,7 @@ export function validatePrivateKey(id: SuiteID, privateKey: Uint8Array): boolean
 
 export function validatePublicKey(id: SuiteID, publicKey: Uint8Array): boolean {
     try {
-        const P = Elt.deserialize(Oprf.getGroup(id), publicKey)
+        const P = Oprf.getGroup(id).desElt(publicKey)
         return !P.isIdentity()
     } catch (_) {
         return false
@@ -65,7 +65,7 @@ export async function derivePrivateKey(
 
 export function generatePublicKey(id: SuiteID, privateKey: Uint8Array): Uint8Array {
     const gg = Oprf.getGroup(id)
-    const priv = Scalar.deserialize(gg, privateKey)
+    const priv = gg.desScalar(privateKey)
     const pub = gg.mulGen(priv)
     return pub.serialize()
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
+import { Deserializer } from './groupTypes.js'
+
 export function joinAll(a: Uint8Array[]): Uint8Array {
     let size = 0
     for (let i = 0; i < a.length; i++) {
@@ -76,26 +78,22 @@ export function fromU16LenPrefix(b: Uint8Array): { head: Uint8Array; tail: Uint8
     return { head, tail }
 }
 
-export function fromU16LenPrefixClass<T, U>(
-    c: {
-        size: (u: U) => number
-        deserialize: (u: U, b: Uint8Array) => T
-    },
-    u: U,
+export function fromU16LenPrefixDes<T>(
+    c: Deserializer<T>,
     b: Uint8Array
 ): { head: T[]; tail: Uint8Array } {
     if (b.length < 2) {
         throw new Error(`buffer shorter than expected`)
     }
     const n = (b[0] << 8) | b[1]
-    const size = c.size(u)
+    const size = c.size()
     if (b.length < 2 + n * size) {
         throw new Error(`buffer shorter than expected`)
     }
 
     const head: T[] = []
     for (let i = 0; i < n; i++) {
-        head.push(c.deserialize(u, b.subarray(2 + i * size, 2 + (i + 1) * size)))
+        head.push(c.deserialize(b.subarray(2 + i * size, 2 + (i + 1) * size)))
     }
 
     const tail = b.subarray(2 + n * size)

--- a/test/dleq.test.ts
+++ b/test/dleq.test.ts
@@ -3,12 +3,12 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { DLEQParams, DLEQProof, DLEQProver, Elt, Group, Scalar } from '../src/index.js'
+import { DLEQParams, DLEQProof, DLEQProver, Elt, Oprf, Scalar } from '../src/index.js'
 
 import { serdeClass } from './util.js'
 
-describe.each(Object.entries(Group.ID))('DLEQ', (groupName, id) => {
-    const gg = new Group(id)
+describe.each(Object.entries(Oprf.Group.ID))('DLEQ', (groupName, id) => {
+    const gg = new Oprf.Group(id)
     const params: DLEQParams = { gg, hash: 'SHA-256', dst: 'domain-sep' }
     const Peggy = new DLEQProver(params)
 

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -3,9 +3,10 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { Elt, Group, Scalar } from '../src/index.js'
-
 import { serdeClass } from './util.js'
+import { Oprf } from '../src'
+
+const Group = Oprf.Group
 
 describe.each(Object.entries(Group.ID))('%s', (_groupName, id) => {
     const gg = new Group(id)
@@ -15,7 +16,7 @@ describe.each(Object.entries(Group.ID))('%s', (_groupName, id) => {
 
         for (const compress of [true, false]) {
             const serP = P.serialize(compress)
-            const Q = Elt.deserialize(gg, serP)
+            const Q = gg.desElt(serP)
             expect(P.isEqual(Q)).toBe(true)
         }
     })
@@ -23,18 +24,18 @@ describe.each(Object.entries(Group.ID))('%s', (_groupName, id) => {
     it('serdeElementZero', () => {
         const Z = gg.identity()
 
-        expect(serdeClass(Elt, Z, gg)).toBe(true)
+        expect(serdeClass(Group.Elt, Z, gg)).toBe(true)
     })
 
     it('serdeScalar', async () => {
         const k = await gg.randomScalar()
 
-        expect(serdeClass(Scalar, k, gg)).toBe(true)
+        expect(serdeClass(Group.Scalar, k, gg)).toBe(true)
     })
 
     it('serdeScalarZero', () => {
         const z = gg.newScalar()
 
-        expect(serdeClass(Scalar, z, gg)).toBe(true)
+        expect(serdeClass(Group.Scalar, z, gg)).toBe(true)
     })
 })

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -4,10 +4,10 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import {
-    Oprf,
     deriveKeyPair,
     generateKeyPair,
     getKeySizes,
+    Oprf,
     validatePrivateKey,
     validatePublicKey
 } from '../src/index.js'

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -7,15 +7,15 @@ import {
     Evaluation,
     EvaluationRequest,
     FinalizeData,
+    generatePublicKey,
+    Oprf,
     OPRFClient,
     OPRFServer,
-    Oprf,
     POPRFClient,
     POPRFServer,
+    randomPrivateKey,
     VOPRFClient,
-    VOPRFServer,
-    generatePublicKey,
-    randomPrivateKey
+    VOPRFServer
 } from '../src/index.js'
 
 import { serdeClass } from './util.js'

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { Elt, Group, OPRFClient, OPRFServer, Oprf, Scalar, randomPrivateKey } from '../src/index.js'
+import { Oprf, OPRFClient, OPRFServer, randomPrivateKey } from '../src/index.js'
 
 import { jest } from '@jest/globals'
 
@@ -32,10 +32,10 @@ function mockImportKey(...x: Parameters<typeof importKey>): ReturnType<typeof im
 function mockSign(...x: Parameters<typeof sign>): ReturnType<typeof sign> {
     const [algorithm, key, data] = x
     if (algorithm === 'OPRF') {
-        const g = new Group(Group.getID((key.algorithm as EcdsaParams).name))
-        const P = Elt.deserialize(g, new Uint8Array(data as ArrayBuffer))
+        const g = new Oprf.Group(Oprf.Group.getID((key.algorithm as EcdsaParams).name))
+        const P = g.desElt(new Uint8Array(data as ArrayBuffer))
         const serSk = new Uint8Array((key as CryptoKeyWithBuffer).keyData)
-        const sk = Scalar.deserialize(g, serSk)
+        const sk = g.desScalar(serSk)
         const Z = P.mul(sk)
         const serZ = Z.serialize()
         return Promise.resolve(serZ.buffer as ArrayBuffer)

--- a/test/vectors.test.ts
+++ b/test/vectors.test.ts
@@ -4,18 +4,17 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import {
+    derivePrivateKey,
+    generatePublicKey,
     ModeID,
+    Oprf,
     OPRFClient,
     OPRFServer,
-    Oprf,
     POPRFClient,
     POPRFServer,
-    Scalar,
     SuiteID,
     VOPRFClient,
-    VOPRFServer,
-    derivePrivateKey,
-    generatePublicKey
+    VOPRFServer
 } from '../src/index.js'
 
 // Test vectors taken from reference implementation at https://github.com/cfrg/draft-irtf-cfrg-voprf
@@ -123,9 +122,8 @@ describe.each(allVectors)('test-vectors', (testVector: typeof allVectors[number]
                 for (const c of [OPRFClient, VOPRFClient, wrapPOPRFClient]) {
                     let i = 0
                     jest.spyOn(c.prototype, 'randomBlinder').mockImplementation(() => {
-                        return Promise.resolve(
-                            Scalar.deserialize(Oprf.getGroup(id), fromHexList(vi.Blind)[i++])
-                        )
+                        const group = Oprf.getGroup(id)
+                        return Promise.resolve(group.desScalar(fromHexList(vi.Blind)[i++]))
                     })
                 }
 


### PR DESCRIPTION
#  Pluggable Group as easily reviewed first step to @noble support

@cloudflare has currently limited attentional bandwidth to comfortably switch out sjcl for (more performant/secure/maintained) @noble/{curves,hashes} and needs time for a review process. There were some concerns about swapping out the Group implementation wholesale, so this attempts as a logical first step to restructure the code to allow plugging in multiple implementations. 

## Add indirection

The current code makes direct uses of the implementation classes `Group`/`Elt`/`Scalar` everywhere directly. We extract interface for the instances and constructors and place in `src/groupTypes.ts`. 

The Oprf class, already home to many constants and a `getGroup(suiteId)` is endowed with a getter/setter for a Group property, of type `GroupCons`. 

#### Set a default Group

Scjl Group will be configured by default. This, of course, would mean bundling (i.e. webpack) sjcl even where it's not used/needed, but at least it's pluggable!
