### PR TITLE
chore: put vendored sjcl into devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "@cloudflare/voprf-ts",
             "version": "0.21.0",
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "sjcl": "1.0.8"
-            },
             "devDependencies": {
                 "@types/benchmark": "2.1.2",
                 "@types/jest": "29.2.3",
@@ -25,6 +22,7 @@
                 "eslint-plugin-security": "1.5.0",
                 "jest": "29.3.1",
                 "prettier": "2.7.1",
+                "sjcl": "1.0.8",
                 "typescript": "4.8.4"
             },
             "engines": {
@@ -4358,6 +4356,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
             "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -8018,7 +8017,8 @@
         "sjcl": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-            "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
+            "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+            "dev": true
         },
         "slash": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "eslint-plugin-security": "1.5.0",
         "jest": "29.3.1",
         "prettier": "2.7.1",
+        "sjcl": "1.0.8",
         "typescript": "4.8.4"
     },
     "scripts": {
@@ -52,8 +53,5 @@
         "lint": "eslint .",
         "bench": "tsc -b bench && node ./lib/bench/index.js",
         "format": "prettier './(src|test|bench|examples)/*.ts' --write"
-    },
-    "dependencies": {
-        "sjcl": "1.0.8"
     }
 }


### PR DESCRIPTION
sjcl is built, vendored (and source controlled) so putting it as a production dependency is redundant