### PR TITLE
feat: implement GroupNoble

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -5,7 +5,7 @@
     "testEnvironment": "node",
     "transform": {},
     "setupFiles": [
-        "./test/jest.setup-file.js"
+        "./test/jest.setup-file.mjs"
     ],
     "collectCoverage": true,
     "collectCoverageFrom": [

--- a/lib/cjs/package.json
+++ b/lib/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.21.0",
             "license": "BSD-3-Clause",
             "devDependencies": {
+                "@noble/curves": "^1.1.0",
+                "@noble/hashes": "^1.3.1",
                 "@types/benchmark": "2.1.2",
                 "@types/jest": "29.2.3",
                 "@typescript-eslint/eslint-plugin": "5.60.0",
@@ -20,13 +22,17 @@
                 "eslint-plugin-jest-formatting": "3.1.0",
                 "eslint-plugin-prettier": "4.2.1",
                 "eslint-plugin-security": "1.7.1",
-                "jest": "29.3.1",
+                "jest": "29.5.0",
                 "prettier": "2.8.8",
                 "sjcl": "1.0.8",
                 "typescript": "5.1.3"
             },
             "engines": {
                 "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@noble/curves": "^1.1.0",
+                "@noble/hashes": "^1.3.1"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1156,6 +1162,30 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "dev": true
+        },
+        "node_modules/@noble/curves": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+            "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+            "dev": true,
+            "dependencies": {
+                "@noble/hashes": "1.3.1"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2998,15 +3028,15 @@
             }
         },
         "node_modules/jest": {
-            "version": "29.3.1",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.3.1.tgz",
-            "integrity": "sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==",
+            "version": "29.5.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
+            "integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
             "dev": true,
             "dependencies": {
-                "@jest/core": "^29.3.1",
-                "@jest/types": "^29.3.1",
+                "@jest/core": "^29.5.0",
+                "@jest/types": "^29.5.0",
                 "import-local": "^3.0.2",
-                "jest-cli": "^29.3.1"
+                "jest-cli": "^29.5.0"
             },
             "bin": {
                 "jest": "bin/jest.js"

--- a/package.json
+++ b/package.json
@@ -6,14 +6,26 @@
     "maintainers": [
         "Armando Faz <armfazh@cloudflare.com>"
     ],
+    "contributors": [
+        "Nicholas Dudfield <ndudfield@gmail.com>"
+    ],
     "license": "BSD-3-Clause",
     "private": false,
-    "type": "module",
-    "main": "./lib/src/index.js",
-    "module": "./lib/src/index.js",
-    "types": "./lib/src/index.d.ts",
+    "main": "./lib/cjs/src/index.js",
+    "module": "./lib/esm/src/index.js",
+    "exports": {
+        ".": {
+            "require": "./lib/cjs/src/index.js",
+            "import": "./lib/esm/src/index.js"
+        },
+        "./group-noble": {
+            "require" : "./lib/cjs/src/groupNoble.js",
+            "import" : "./lib/esm/src/groupNoble.js"
+        }
+    },
+    "types": "./lib/esm/src/index.d.ts",
     "files": [
-        "lib/src/**/*.!(tsbuildinfo)",
+        "lib/*/src/**/*.!(tsbuildinfo)",
         "webcrypto.md"
     ],
     "keywords": [
@@ -40,20 +52,28 @@
         "eslint-plugin-jest-formatting": "3.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-security": "1.7.1",
-        "jest": "29.3.1",
+        "jest": "29.5.0",
         "prettier": "2.8.8",
+        "sjcl": "1.0.8",
         "typescript": "5.1.3",
-        "sjcl": "1.0.8"
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1"
     },
     "scripts": {
-        "prepack": "tsc -b",
-        "prepare": "tsc -b",
-        "build": "tsc -b",
-        "clean": "tsc -b --clean . test",
-        "test": "tsc -b test && node --experimental-vm-modules ./node_modules/jest/bin/jest.js --ci",
-        "examples": "tsc -b examples && node ./lib/examples/index.js",
+        "prepack": "tsc -b . tsconfig.cjs.json",
+        "prepare": "tsc -b . tsconfig.cjs.json" ,
+        "build": "tsc -b . tsconfig.cjs.json",
+        "clean": "tsc -b --clean . test ./tsconfig.cjs.json test/tsconfig.cjs.json bench examples",
+        "test": "tsc -b test test/tsconfig.cjs.json && node --experimental-vm-modules node_modules/.bin/jest --ci",
+        "test:esm": "tsc -b test && node --experimental-vm-modules node_modules/.bin/jest --ci ./lib/esm/**/*.test.js",
+        "test:cjs": "tsc -b test/tsconfig.cjs.json && node --experimental-vm-modules node_modules/.bin/jest --ci ./lib/cjs/**/*.test.js",
+        "examples": "tsc -b examples && node ./lib/esm/examples/index.js",
         "lint": "eslint .",
-        "bench": "tsc -b bench && node ./lib/bench/index.js",
+        "bench": "tsc -b bench && node ./lib/esm/bench/index.js",
         "format": "prettier './(src|test|bench|examples)/*.ts' --write"
+    },
+    "optionalDependencies": {
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1"
     }
 }

--- a/src/groupNoble.ts
+++ b/src/groupNoble.ts
@@ -301,21 +301,14 @@ class GroupNb implements Group {
         return ScalarNb.hash(this, msg, dst)
     }
 
-    eltDes: Deserializer<EltNb> = {
-        size: (compressed?: boolean) => {
-            return this.eltSize(compressed)
-        },
-        deserialize: (b: Uint8Array) => {
-            return this.desElt(b)
-        }
+    readonly eltDes: Deserializer<EltNb> = {
+        size: (compressed) => this.eltSize(compressed),
+        deserialize: (b) => this.desElt(b)
     }
-    scalarDes: Deserializer<ScalarNb> = {
-        size: () => {
-            return this.scalarSize()
-        },
-        deserialize: (b: Uint8Array) => {
-            return this.desScalar(b)
-        }
+
+    readonly scalarDes: Deserializer<ScalarNb> = {
+        size: () => this.scalarSize(),
+        deserialize: (b) => this.desScalar(b)
     }
 
     desElt(bytes: Uint8Array): EltNb {

--- a/src/groupNoble.ts
+++ b/src/groupNoble.ts
@@ -1,0 +1,338 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors.
+// Copyright (c) 2021 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or
+// at https://opensource.org/licenses/BSD-3-Clause
+
+import { checkSize } from './util.js'
+import * as p256 from '@noble/curves/p256'
+import * as p384 from '@noble/curves/p384'
+import * as p521 from '@noble/curves/p521'
+import { Field } from '@noble/curves/abstract/modular'
+import { bytesToNumberBE } from '@noble/curves/abstract/utils'
+import { hash_to_field } from '@noble/curves/abstract/hash-to-curve'
+import { CurveFn, ProjConstructor, ProjPointType } from '@noble/curves/abstract/weierstrass'
+import { CHash } from '@noble/hashes/utils'
+import {
+    Deserializer,
+    Elt,
+    EltCons,
+    Group,
+    GroupCons,
+    GroupID,
+    GroupIDs,
+    Scalar,
+    ScalarCons
+} from './groupTypes.js'
+
+type FieldFn = ReturnType<typeof Field>
+type H2CFn = typeof p256.hashToCurve
+type NobleModule<K extends string> = Record<K, CurveFn> & { hashToCurve: H2CFn }
+
+interface GroupParams {
+    scalarField: FieldFn
+    Point: ProjConstructor<bigint>
+    h2c: H2CFn
+    size: number
+    hashToScalar: {
+        hash: CHash
+        k: number
+        p: bigint
+    }
+}
+
+function makeParams<K extends string>(
+    k: K,
+    module: NobleModule<K>,
+    securityBits: number
+): GroupParams {
+    const curve = Reflect.get(module, k)
+    return {
+        scalarField: Field(curve.CURVE.n),
+        Point: curve.ProjectivePoint,
+        h2c: module.hashToCurve,
+        size: curve.CURVE.Fp.BYTES,
+        hashToScalar: {
+            hash: curve.CURVE.hash,
+            p: curve.CURVE.n,
+            k: securityBits
+        }
+    }
+}
+
+const GROUPS: Record<GroupID, GroupParams> = {
+    [GroupIDs.P256]: makeParams('p256', p256, 128),
+    [GroupIDs.P384]: makeParams('p384', p384, 192),
+    [GroupIDs.P521]: makeParams('p521', p521, 256)
+}
+
+function getParams(gid: GroupID) {
+    if (!Object.values(GroupIDs).includes(gid)) throw errBadGroup(gid)
+    // eslint-disable-next-line security/detect-object-injection
+    return GROUPS[gid]
+}
+
+function errDeserialization(T: { name: string }) {
+    return new Error(`group: deserialization of ${T.name} failed.`)
+}
+
+function errGroup(X: GroupID, Y: GroupID) {
+    return new Error(`group: mismatch between groups ${X} and ${Y}.`)
+}
+
+function errBadGroup(X: string) {
+    return new Error(`group: bad group name ${X}.`)
+}
+
+function compat(x: { g: Group }, y: { g: Group }): void | never {
+    if (x.g.id !== y.g.id) throw errGroup(x.g.id, y.g.id)
+}
+
+// TODO: h2c/h2f only accepts a string, otherwise throws an error, open an issue
+function decodeDST(val: Uint8Array): string {
+    return new TextDecoder().decode(val)
+}
+
+class ScalarNb implements Scalar {
+    private readonly field: FieldFn
+    public readonly k: bigint
+
+    private constructor(public readonly g: GroupNb, k: bigint) {
+        this.field = this.g.params.scalarField
+        this.k = this.field.create(k)
+    }
+
+    static new(g: GroupNb): ScalarNb {
+        return new ScalarNb(g, BigInt(0))
+    }
+
+    isEqual(s: ScalarNb): boolean {
+        return this.k === s.k
+    }
+
+    isZero(): boolean {
+        return this.k === BigInt(0)
+    }
+
+    add(s: ScalarNb): ScalarNb {
+        compat(this, s)
+        return new ScalarNb(this.g, this.field.add(this.k, s.k))
+    }
+
+    sub(s: ScalarNb): ScalarNb {
+        compat(this, s)
+        return new ScalarNb(this.g, this.field.sub(this.k, s.k))
+    }
+
+    mul(s: ScalarNb): ScalarNb {
+        compat(this, s)
+        return new ScalarNb(this.g, this.field.mul(this.k, s.k))
+    }
+
+    inv(): ScalarNb {
+        return new ScalarNb(this.g, this.field.inv(this.k))
+    }
+
+    serialize(): Uint8Array {
+        const k = this.field.create(this.k)
+        const ab = this.field.toBytes(k)
+        const unPadded = new Uint8Array(ab)
+        const serScalar = new Uint8Array(this.g.size)
+        serScalar.set(unPadded, this.g.size - unPadded.length)
+        return serScalar
+    }
+
+    static size(g: GroupNb): number {
+        return g.size
+    }
+
+    static deserialize(g: GroupNb, bytes: Uint8Array): ScalarNb {
+        checkSize(bytes, ScalarNb, g)
+        const array = bytes.subarray(0, g.size)
+        const k = bytesToNumberBE(array)
+        if (k >= g.params.scalarField.ORDER) {
+            throw errDeserialization(ScalarNb)
+        }
+        return new ScalarNb(g, k)
+    }
+
+    static hash(g: GroupNb, msg: Uint8Array, dst: Uint8Array): ScalarNb {
+        const [[k]] = hash_to_field(msg, 1, {
+            ...g.params.hashToScalar,
+            expand: 'xmd',
+            DST: decodeDST(dst),
+            m: 1
+        })
+        return new ScalarNb(g, k)
+    }
+}
+
+class EltNb implements Elt {
+    private constructor(public readonly g: GroupNb, private readonly p: ProjPointType<bigint>) {}
+
+    static new(g: GroupNb): EltNb {
+        return new EltNb(g, g.params.Point.ZERO)
+    }
+
+    static gen(g: GroupNb): EltNb {
+        return new EltNb(g, g.params.Point.BASE)
+    }
+
+    isIdentity(): boolean {
+        return this.p.equals(this.g.params.Point.ZERO)
+    }
+
+    isEqual(a: EltNb): boolean {
+        compat(this, a)
+        return this.p.equals(a.p)
+    }
+
+    neg(): EltNb {
+        return new EltNb(this.g, this.p.negate())
+    }
+
+    add(a: EltNb): EltNb {
+        compat(this, a)
+        return new EltNb(this.g, this.p.add(a.p))
+    }
+
+    mul(s: ScalarNb): EltNb {
+        compat(this, s)
+        return new EltNb(this.g, this.p.multiply(s.k))
+    }
+
+    mul2(k1: ScalarNb, a: EltNb, k2: ScalarNb): EltNb {
+        compat(this, k1)
+        compat(this, k2)
+        compat(this, a)
+        const zero = this.g.params.Point.ZERO
+        const el = this.p.multiplyAndAddUnsafe(a.p, k1.k, k2.k) ?? zero
+        return new EltNb(this.g, el)
+    }
+
+    serialize(compressed = true): Uint8Array {
+        if (this.isIdentity()) {
+            return Uint8Array.from([0])
+        }
+        return this.p.toRawBytes(compressed)
+    }
+
+    // size returns the number of bytes of a non-zero element in compressed or uncompressed form.
+    static size(g: GroupNb, compressed = true): number {
+        return 1 + (compressed ? g.size : g.size * 2)
+    }
+
+    private static deser(g: GroupNb, bytes: Uint8Array): EltNb {
+        const point = g.params.Point.fromHex(bytes)
+        point.assertValidity()
+        return new EltNb(g, point)
+    }
+
+    // Deserializes an element, handles both compressed and uncompressed forms.
+    static deserialize(g: GroupNb, bytes: Uint8Array): EltNb {
+        const len = bytes.length
+        switch (true) {
+            case len === 1 && bytes[0] === 0x00:
+                return g.identity()
+            case len === 1 + g.size && (bytes[0] === 0x02 || bytes[0] === 0x03):
+                return EltNb.deser(g, bytes)
+            case len === 1 + 2 * g.size && bytes[0] === 0x04:
+                return EltNb.deser(g, bytes)
+            default:
+                throw errDeserialization(EltNb)
+        }
+    }
+
+    static hash(g: GroupNb, msg: Uint8Array, dst: Uint8Array): EltNb {
+        const h2c = g.params.h2c
+        const p = h2c(msg, { DST: decodeDST(dst) }) as ProjPointType<bigint>
+        return new EltNb(g, p)
+    }
+}
+
+class GroupNb implements Group {
+    static readonly Elt: EltCons = EltNb
+    static readonly Scalar: ScalarCons = ScalarNb
+    static readonly ID = GroupIDs
+
+    static fromID(gid: GroupID) {
+        return new this(gid)
+    }
+
+    public readonly params: GroupParams
+    public readonly size: number
+    public readonly id: GroupID
+
+    constructor(gid: GroupID) {
+        this.params = getParams(gid)
+        this.size = this.params.size
+        this.id = gid
+    }
+
+    newScalar(): ScalarNb {
+        return ScalarNb.new(this)
+    }
+
+    newElt(): EltNb {
+        return this.identity()
+    }
+
+    identity(): EltNb {
+        return EltNb.new(this)
+    }
+
+    generator(): EltNb {
+        return EltNb.gen(this)
+    }
+
+    mulGen(s: ScalarNb): EltNb {
+        return EltNb.gen(this).mul(s)
+    }
+
+    randomScalar(): Promise<ScalarNb> {
+        const msg = crypto.getRandomValues(new Uint8Array(this.size))
+        return Promise.resolve(ScalarNb.hash(this, msg, new Uint8Array()))
+    }
+
+    async hashToGroup(msg: Uint8Array, dst: Uint8Array): Promise<EltNb> {
+        return EltNb.hash(this, msg, dst)
+    }
+
+    async hashToScalar(msg: Uint8Array, dst: Uint8Array): Promise<ScalarNb> {
+        return ScalarNb.hash(this, msg, dst)
+    }
+
+    eltDes: Deserializer<EltNb> = {
+        size: (compressed?: boolean) => {
+            return this.eltSize(compressed)
+        },
+        deserialize: (b: Uint8Array) => {
+            return this.desElt(b)
+        }
+    }
+    scalarDes: Deserializer<ScalarNb> = {
+        size: () => {
+            return this.scalarSize()
+        },
+        deserialize: (b: Uint8Array) => {
+            return this.desScalar(b)
+        }
+    }
+
+    desElt(bytes: Uint8Array): EltNb {
+        return EltNb.deserialize(this, bytes)
+    }
+
+    desScalar(bytes: Uint8Array): ScalarNb {
+        return ScalarNb.deserialize(this, bytes)
+    }
+
+    eltSize(compressed?: boolean): number {
+        return EltNb.size(this, compressed)
+    }
+
+    scalarSize(): number {
+        return ScalarNb.size(this)
+    }
+}
+
+export const GroupConsNoble: GroupCons = GroupNb

--- a/src/groupSjcl.ts
+++ b/src/groupSjcl.ts
@@ -6,7 +6,16 @@
 import { checkSize, joinAll, xor } from './util.js'
 
 import sjcl from './sjcl/index.js'
-import { Elt, errBadGroup, Group, GroupCons, GroupID, GroupIDs, Scalar } from './groupTypes.js'
+import {
+    Deserializer,
+    Elt,
+    errBadGroup,
+    Group,
+    GroupCons,
+    GroupID,
+    GroupIDs,
+    Scalar
+} from './groupTypes.js'
 
 function errDeserialization(T: { name: string }) {
     return new Error(`group: deserialization of ${T.name} failed.`)
@@ -530,25 +539,17 @@ class GroupSj implements Group {
         return ScalarSj.hash(this, msg, dst)
     }
 
-    get eltDes() {
+    get eltDes(): Deserializer<EltSj> {
         return {
-            size: (compressed?: boolean): number => {
-                return EltSj.size(this, compressed)
-            },
-            deserialize: (b: Uint8Array): EltSj => {
-                return EltSj.deserialize(this, b)
-            }
+            size: (compressed): number => EltSj.size(this, compressed),
+            deserialize: (b) => EltSj.deserialize(this, b)
         }
     }
 
-    get scalarDes() {
+    get scalarDes(): Deserializer<ScalarSj> {
         return {
-            size: (): number => {
-                return ScalarSj.size(this)
-            },
-            deserialize: (b: Uint8Array): ScalarSj => {
-                return ScalarSj.deserialize(this, b)
-            }
+            size: () => ScalarSj.size(this),
+            deserialize: (b) => ScalarSj.deserialize(this, b)
         }
     }
 

--- a/src/groupSjcl.ts
+++ b/src/groupSjcl.ts
@@ -6,16 +6,7 @@
 import { checkSize, joinAll, xor } from './util.js'
 
 import sjcl from './sjcl/index.js'
-import {
-    Elt,
-    errBadGroup,
-    getGroupID,
-    Group,
-    GroupCons,
-    GroupID,
-    GroupIDs,
-    Scalar
-} from './groupTypes.js'
+import { Elt, errBadGroup, Group, GroupCons, GroupID, GroupIDs, Scalar } from './groupTypes.js'
 
 function errDeserialization(T: { name: string }) {
     return new Error(`group: deserialization of ${T.name} failed.`)
@@ -99,7 +90,7 @@ function getCurve(gid: GroupID): sjcl.ecc.curve {
     }
 }
 
-export class ScalarSj implements Scalar {
+class ScalarSj implements Scalar {
     private readonly order: sjcl.bn
 
     private constructor(public readonly g: GroupSj, private readonly k: sjcl.bn) {
@@ -242,7 +233,7 @@ function getHashParams(gid: GroupID): HashParams {
     }
 }
 
-export class EltSj implements Elt {
+class EltSj implements Elt {
     private constructor(public readonly g: GroupSj, private readonly p: sjcl.ecc.point) {}
 
     static new(g: GroupSj): EltSj {
@@ -482,7 +473,9 @@ class GroupSj implements Group {
     static readonly Elt = EltSj
     static readonly Scalar = ScalarSj
     static readonly ID = GroupIDs
-    static readonly getID = getGroupID
+    static fromID(gid: GroupID) {
+        return new this(gid)
+    }
 
     readonly id: GroupID
     readonly size: number

--- a/src/groupTypes.ts
+++ b/src/groupTypes.ts
@@ -15,19 +15,6 @@ export function errBadGroup(X: string) {
     return new Error(`group: bad group name ${X}.`)
 }
 
-export function getGroupID(id: string): GroupID {
-    switch (id) {
-        case 'P-256':
-            return GroupIDs.P256
-        case 'P-384':
-            return GroupIDs.P384
-        case 'P-521':
-            return GroupIDs.P521
-        default:
-            throw errBadGroup(id)
-    }
-}
-
 export interface Scalar {
     g: Group
 
@@ -107,9 +94,8 @@ export interface Group extends SerializationHelpers {
 }
 
 export interface GroupCons {
-    new (id: GroupID): Group
+    fromID(id: GroupID): Group
     ID: typeof GroupIDs
-    getID: typeof getGroupID
     Elt: EltCons
     Scalar: ScalarCons
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import { GroupConsSjcl } from './groupSjcl.js'
-import { Oprf } from './oprf.js'
 
+import { Oprf } from './oprf.js'
 Oprf.Group = GroupConsSjcl
 
 export * from './groupTypes.js'

--- a/src/oprf.ts
+++ b/src/oprf.ts
@@ -78,7 +78,7 @@ export abstract class Oprf {
         }
     }
     static getGroup(suite: SuiteID): Group {
-        return new Oprf.Group(Oprf.getParams(suite)[1])
+        return Oprf.Group.fromID(Oprf.getParams(suite)[1])
     }
     static getHash(suite: SuiteID): string {
         return Oprf.getParams(suite)[2]
@@ -104,7 +104,7 @@ export abstract class Oprf {
     constructor(mode: ModeID, suite: SuiteID) {
         const [ID, gid, hash] = Oprf.getParams(suite)
         this.ID = ID
-        this.gg = new Oprf.Group(gid)
+        this.gg = Oprf.Group.fromID(gid)
         this.hash = hash
         this.mode = Oprf.validateMode(mode)
     }

--- a/src/sjcl/tsconfig.cjs.json
+++ b/src/sjcl/tsconfig.cjs.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../tsconfig.cjs.json", "./tsconfig.compilerOptions.json"],
+    "files": ["index.js"]
+}

--- a/src/sjcl/tsconfig.compilerOptions.json
+++ b/src/sjcl/tsconfig.compilerOptions.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "declaration": false,
+        "declarationMap": false,
+        "composite": false,
+        "sourceMap": false,
+        "allowJs": true
+    }
+}

--- a/src/sjcl/tsconfig.json
+++ b/src/sjcl/tsconfig.json
@@ -1,12 +1,5 @@
 {
-    "compilerOptions": {
-        "declaration": false,
-        "declarationMap": false,
-        "composite": false,
-        "sourceMap": false,
-        "allowJs": true
-    },
-    "extends": "../../tsconfig.json",
+    "extends": ["../../tsconfig.json", "./tsconfig.compilerOptions.json"],
     "files": [
         "index.js"
     ]

--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tsconfig.cjs.json",
+    "include": [
+        "."
+    ]
+
+}

--- a/test/describeGroupTests.ts
+++ b/test/describeGroupTests.ts
@@ -1,0 +1,21 @@
+import { GroupConsNoble } from '../src/groupNoble.js'
+import { GroupConsSjcl } from '../src/groupSjcl.js'
+import { GroupCons, Oprf } from '../src/index.js'
+
+const groupConsMatch = process.env.GROUP_CONS
+
+export const testGroups = (
+    [
+        ['noble', GroupConsNoble],
+        ['sjcl', GroupConsSjcl]
+    ] as const
+).filter(([name]) => {
+    return !groupConsMatch || name === groupConsMatch
+})
+
+export function describeGroupTests(declare: (group: GroupCons) => void) {
+    describe.each(testGroups)(`Group-%s`, (_groupName, groupCons) => {
+        Oprf.Group = groupCons
+        declare(groupCons)
+    })
+}

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -3,39 +3,39 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
+import { describeGroupTests } from './describeGroupTests.js'
 import { serdeClass } from './util.js'
-import { Oprf } from '../src'
 
-const Group = Oprf.Group
+describeGroupTests((Group) => {
+    describe.each(Object.entries(Group.ID))('%s', (_groupName, id) => {
+        const gg = Group.fromID(id)
 
-describe.each(Object.entries(Group.ID))('%s', (_groupName, id) => {
-    const gg = new Group(id)
+        it('serdeElement', async () => {
+            const P = gg.mulGen(await gg.randomScalar())
 
-    it('serdeElement', async () => {
-        const P = gg.mulGen(await gg.randomScalar())
+            for (const compress of [true, false]) {
+                const serP = P.serialize(compress)
+                const Q = gg.desElt(serP)
+                expect(P.isEqual(Q)).toBe(true)
+            }
+        })
 
-        for (const compress of [true, false]) {
-            const serP = P.serialize(compress)
-            const Q = gg.desElt(serP)
-            expect(P.isEqual(Q)).toBe(true)
-        }
-    })
+        it('serdeElementZero', () => {
+            const Z = gg.identity()
 
-    it('serdeElementZero', () => {
-        const Z = gg.identity()
+            expect(serdeClass(Group.Elt, Z, gg)).toBe(true)
+        })
 
-        expect(serdeClass(Group.Elt, Z, gg)).toBe(true)
-    })
+        it('serdeScalar', async () => {
+            const k = await gg.randomScalar()
 
-    it('serdeScalar', async () => {
-        const k = await gg.randomScalar()
+            expect(serdeClass(Group.Scalar, k, gg)).toBe(true)
+        })
 
-        expect(serdeClass(Group.Scalar, k, gg)).toBe(true)
-    })
+        it('serdeScalarZero', () => {
+            const z = gg.newScalar()
 
-    it('serdeScalarZero', () => {
-        const z = gg.newScalar()
-
-        expect(serdeClass(Group.Scalar, z, gg)).toBe(true)
+            expect(serdeClass(Group.Scalar, z, gg)).toBe(true)
+        })
     })
 })

--- a/test/jest.setup-file.mjs
+++ b/test/jest.setup-file.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors.
+// Copyright (c) 2021 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or
+// at https://opensource.org/licenses/BSD-3-Clause
+
+// Mocking crypto with NodeJS webcrypto module only for tests.
+import { webcrypto } from 'node:crypto'
+
+if (typeof crypto === 'undefined') {
+    global.crypto = webcrypto
+}

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -11,67 +11,70 @@ import {
     validatePrivateKey,
     validatePublicKey
 } from '../src/index.js'
+import { describeGroupTests } from './describeGroupTests.js'
 
-describe.each(Object.entries(Oprf.Suite))('oprf-keys', (name, id) => {
-    describe(`${name}`, () => {
-        const { Nsk, Npk } = getKeySizes(id)
-        const gg = Oprf.getGroup(id)
+describeGroupTests((_g) => {
+    describe.each(Object.entries(Oprf.Suite))('oprf-keys', (name, id) => {
+        describe(`${name}`, () => {
+            const { Nsk, Npk } = getKeySizes(id)
+            const gg = Oprf.getGroup(id)
 
-        it('getKeySizes', () => {
-            expect(Nsk).toBe(Npk - 1)
-        })
+            it('getKeySizes', () => {
+                expect(Nsk).toBe(Npk - 1)
+            })
 
-        it('zeroPrivateKey', () => {
-            const zeroKeyBytes = new Uint8Array(Nsk)
-            const ret = validatePrivateKey(id, zeroKeyBytes)
-            expect(ret).toBe(false)
-        })
+            it('zeroPrivateKey', () => {
+                const zeroKeyBytes = new Uint8Array(Nsk)
+                const ret = validatePrivateKey(id, zeroKeyBytes)
+                expect(ret).toBe(false)
+            })
 
-        it('badPrivateKey', () => {
-            const bad = new Uint8Array(100)
-            bad.fill(0xff)
-            const ret = validatePrivateKey(id, bad)
-            expect(ret).toBe(false)
-        })
+            it('badPrivateKey', () => {
+                const bad = new Uint8Array(100)
+                bad.fill(0xff)
+                const ret = validatePrivateKey(id, bad)
+                expect(ret).toBe(false)
+            })
 
-        it('onesPrivateKey', () => {
-            const onesKeyBytes = new Uint8Array(Nsk).fill(0xff)
-            const ret = validatePrivateKey(id, onesKeyBytes)
-            expect(ret).toBe(false)
-        })
+            it('onesPrivateKey', () => {
+                const onesKeyBytes = new Uint8Array(Nsk).fill(0xff)
+                const ret = validatePrivateKey(id, onesKeyBytes)
+                expect(ret).toBe(false)
+            })
 
-        it('identityPublicKey', () => {
-            const identityKeyBytes = gg.identity().serialize()
-            const ret = validatePublicKey(id, identityKeyBytes)
-            expect(ret).toBe(false)
-        })
+            it('identityPublicKey', () => {
+                const identityKeyBytes = gg.identity().serialize()
+                const ret = validatePublicKey(id, identityKeyBytes)
+                expect(ret).toBe(false)
+            })
 
-        it('onesPublicKey', () => {
-            const onesKeyBytes = new Uint8Array(Npk).fill(0xff)
-            const ret = validatePublicKey(id, onesKeyBytes)
-            expect(ret).toBe(false)
-        })
+            it('onesPublicKey', () => {
+                const onesKeyBytes = new Uint8Array(Npk).fill(0xff)
+                const ret = validatePublicKey(id, onesKeyBytes)
+                expect(ret).toBe(false)
+            })
 
-        it('generateKeyPair', async () => {
-            for (let i = 0; i < 64; i++) {
-                const keys = await generateKeyPair(id) // eslint-disable-line no-await-in-loop
-                const sk = validatePrivateKey(id, keys.privateKey)
-                const pk = validatePublicKey(id, keys.publicKey)
-                expect(sk).toBe(true)
-                expect(pk).toBe(true)
-            }
-        })
+            it('generateKeyPair', async () => {
+                for (let i = 0; i < 64; i++) {
+                    const keys = await generateKeyPair(id) // eslint-disable-line no-await-in-loop
+                    const sk = validatePrivateKey(id, keys.privateKey)
+                    const pk = validatePublicKey(id, keys.publicKey)
+                    expect(sk).toBe(true)
+                    expect(pk).toBe(true)
+                }
+            })
 
-        it('deriveKeyPair', async () => {
-            const info = new TextEncoder().encode('info used for derivation')
-            for (let i = 0; i < 64; i++) {
-                const seed = crypto.getRandomValues(new Uint8Array(Nsk))
-                const keys = await deriveKeyPair(Oprf.Mode.OPRF, id, seed, info) // eslint-disable-line no-await-in-loop
-                const sk = validatePrivateKey(id, keys.privateKey)
-                const pk = validatePublicKey(id, keys.publicKey)
-                expect(sk).toBe(true)
-                expect(pk).toBe(true)
-            }
+            it('deriveKeyPair', async () => {
+                const info = new TextEncoder().encode('info used for derivation')
+                for (let i = 0; i < 64; i++) {
+                    const seed = crypto.getRandomValues(new Uint8Array(Nsk))
+                    const keys = await deriveKeyPair(Oprf.Mode.OPRF, id, seed, info) // eslint-disable-line no-await-in-loop
+                    const sk = validatePrivateKey(id, keys.privateKey)
+                    const pk = validatePublicKey(id, keys.publicKey)
+                    expect(sk).toBe(true)
+                    expect(pk).toBe(true)
+                }
+            })
         })
     })
 })

--- a/test/oprf.test.ts
+++ b/test/oprf.test.ts
@@ -17,6 +17,7 @@ import {
     VOPRFClient,
     VOPRFServer
 } from '../src/index.js'
+import { describeGroupTests } from './describeGroupTests.js'
 
 import { serdeClass } from './util.js'
 
@@ -32,65 +33,67 @@ async function testBadProof(
     await expect(client.finalize(finData, badEval)).rejects.toThrow(/proof failed/)
 }
 
-describe.each(Object.entries(Oprf.Mode))('protocol', (modeName, mode) => {
-    describe.each(Object.entries(Oprf.Suite))(`${modeName}`, (suiteName, id) => {
-        let server: OPRFServer | VOPRFServer | POPRFServer
-        let client: OPRFClient | VOPRFClient | POPRFClient
+describeGroupTests((_g) => {
+    describe.each(Object.entries(Oprf.Mode))('protocol', (modeName, mode) => {
+        describe.each(Object.entries(Oprf.Suite))(`${modeName}`, (suiteName, id) => {
+            let server: OPRFServer | VOPRFServer | POPRFServer
+            let client: OPRFClient | VOPRFClient | POPRFClient
 
-        beforeAll(async () => {
-            const privateKey = await randomPrivateKey(id)
-            const publicKey = generatePublicKey(id, privateKey)
-            switch (mode) {
-                case Oprf.Mode.OPRF:
-                    server = new OPRFServer(id, privateKey)
-                    client = new OPRFClient(id)
-                    break
+            beforeAll(async () => {
+                const privateKey = await randomPrivateKey(id)
+                const publicKey = generatePublicKey(id, privateKey)
+                switch (mode) {
+                    case Oprf.Mode.OPRF:
+                        server = new OPRFServer(id, privateKey)
+                        client = new OPRFClient(id)
+                        break
 
-                case Oprf.Mode.VOPRF:
-                    server = new VOPRFServer(id, privateKey)
-                    client = new VOPRFClient(id, publicKey)
-                    break
-                case Oprf.Mode.POPRF:
-                    server = new POPRFServer(id, privateKey)
-                    client = new POPRFClient(id, publicKey)
-                    break
-            }
-        })
+                    case Oprf.Mode.VOPRF:
+                        server = new VOPRFServer(id, privateKey)
+                        client = new VOPRFClient(id, publicKey)
+                        break
+                    case Oprf.Mode.POPRF:
+                        server = new POPRFServer(id, privateKey)
+                        client = new POPRFClient(id, publicKey)
+                        break
+                }
+            })
 
-        it(`${suiteName}`, async () => {
-            // Client                                       Server
-            // ====================================================
-            // Client
-            // blind, blindedElement = Blind(input)
-            const input = new TextEncoder().encode('This is the client input')
-            const [finData, evalReq] = await client.blind([input])
-            //             evalReq
-            //       ------------------>>
-            //                                              Server
-            //          evaluation = BlindEvaluate(evalReq, info*)
-            const evaluation = await server.blindEvaluate(evalReq)
-            //            evaluation
-            //       <<------------------
-            //
-            // Client
-            // output = Finalize(finData, evaluation, info*)
-            //
-            const output = await client.finalize(finData, evaluation)
-            expect(output[0]).toHaveLength(Oprf.getOprfSize(id))
+            it(`${suiteName}`, async () => {
+                // Client                                       Server
+                // ====================================================
+                // Client
+                // blind, blindedElement = Blind(input)
+                const input = new TextEncoder().encode('This is the client input')
+                const [finData, evalReq] = await client.blind([input])
+                //             evalReq
+                //       ------------------>>
+                //                                              Server
+                //          evaluation = BlindEvaluate(evalReq, info*)
+                const evaluation = await server.blindEvaluate(evalReq)
+                //            evaluation
+                //       <<------------------
+                //
+                // Client
+                // output = Finalize(finData, evaluation, info*)
+                //
+                const output = await client.finalize(finData, evaluation)
+                expect(output[0]).toHaveLength(Oprf.getOprfSize(id))
 
-            if (evaluation.proof) {
-                await testBadProof(client, server, finData, evaluation)
-            }
+                if (evaluation.proof) {
+                    await testBadProof(client, server, finData, evaluation)
+                }
 
-            const serverOutput = await server.evaluate(input)
-            expect(output[0]).toStrictEqual(serverOutput)
+                const serverOutput = await server.evaluate(input)
+                expect(output[0]).toStrictEqual(serverOutput)
 
-            const success = await server.verifyFinalize(input, output[0])
-            expect(success).toBe(true)
+                const success = await server.verifyFinalize(input, output[0])
+                expect(success).toBe(true)
 
-            expect(serdeClass(FinalizeData, finData, client.gg)).toBe(true)
-            expect(serdeClass(EvaluationRequest, evalReq, client.gg)).toBe(true)
-            expect(serdeClass(Evaluation, evaluation, server.constructDLEQParams())).toBe(true)
+                expect(serdeClass(FinalizeData, finData, client.gg)).toBe(true)
+                expect(serdeClass(EvaluationRequest, evalReq, client.gg)).toBe(true)
+                expect(serdeClass(Evaluation, evaluation, server.constructDLEQParams())).toBe(true)
+            })
         })
     })
 })

--- a/test/tsconfig.cjs.json
+++ b/test/tsconfig.cjs.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../tsconfig.cjs.json",
+    "include": [
+        ".",
+        "testdata/*.json"
+    ],
+    "compilerOptions": {
+        "resolveJsonModule": true
+    },
+    "references": [
+        {
+            "path": "../tsconfig.cjs.json"
+        }
+    ]
+}

--- a/test/vectors.test.ts
+++ b/test/vectors.test.ts
@@ -16,6 +16,7 @@ import {
     VOPRFClient,
     VOPRFServer
 } from '../src/index.js'
+import { describeGroupTests } from './describeGroupTests.js'
 
 // Test vectors taken from reference implementation at https://github.com/cfrg/draft-irtf-cfrg-voprf
 import allVectors from './testdata/allVectors_v20.json'
@@ -69,85 +70,87 @@ class wrapPOPRFClient extends POPRFClient {
     }
 }
 
-// Test vectors from https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf
-// https://tools.ietf.org/html/draft-irtf-cfrg-voprf-11
-describe.each(allVectors)('test-vectors', (testVector: (typeof allVectors)[number]) => {
-    const mode = testVector.mode as ModeID
-    const txtMode = Object.entries(Oprf.Mode)[mode as number][0]
-    const describe_or_skip = (Object.values(Oprf.Suite) as readonly string[]).includes(
-        testVector.identifier
-    )
-        ? describe
-        : describe.skip
-    const id = testVector.identifier as SuiteID
+describeGroupTests((_g) => {
+    // Test vectors from https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf
+    // https://tools.ietf.org/html/draft-irtf-cfrg-voprf-11
+    describe.each(allVectors)('test-vectors', (testVector: (typeof allVectors)[number]) => {
+        const mode = testVector.mode as ModeID
+        const txtMode = Object.entries(Oprf.Mode)[mode as number][0]
+        const describe_or_skip = (Object.values(Oprf.Suite) as readonly string[]).includes(
+            testVector.identifier
+        )
+            ? describe
+            : describe.skip
+        const id = testVector.identifier as SuiteID
 
-    describe_or_skip(`${txtMode}, ${id}`, () => {
-        let skSm: Uint8Array
-        let server: OPRFServer | VOPRFServer | wrapPOPRFServer
-        let client: OPRFClient | VOPRFClient | wrapPOPRFClient
+        describe_or_skip(`${txtMode}, ${id}`, () => {
+            let skSm: Uint8Array
+            let server: OPRFServer | VOPRFServer | wrapPOPRFServer
+            let client: OPRFClient | VOPRFClient | wrapPOPRFClient
 
-        beforeAll(async () => {
-            const seed = fromHex(testVector.seed)
-            const keyInfo = fromHex(testVector.keyInfo)
-            skSm = await derivePrivateKey(mode, id, seed, keyInfo)
-            const pkSm = generatePublicKey(id, skSm)
-            switch (mode) {
-                case Oprf.Mode.OPRF:
-                    server = new OPRFServer(id, skSm)
-                    client = new OPRFClient(id)
-                    break
+            beforeAll(async () => {
+                const seed = fromHex(testVector.seed)
+                const keyInfo = fromHex(testVector.keyInfo)
+                skSm = await derivePrivateKey(mode, id, seed, keyInfo)
+                const pkSm = generatePublicKey(id, skSm)
+                switch (mode) {
+                    case Oprf.Mode.OPRF:
+                        server = new OPRFServer(id, skSm)
+                        client = new OPRFClient(id)
+                        break
 
-                case Oprf.Mode.VOPRF:
-                    server = new VOPRFServer(id, skSm)
-                    client = new VOPRFClient(id, pkSm)
-                    break
+                    case Oprf.Mode.VOPRF:
+                        server = new VOPRFServer(id, skSm)
+                        client = new VOPRFClient(id, pkSm)
+                        break
 
-                case Oprf.Mode.POPRF:
-                    server = new wrapPOPRFServer(id, skSm)
-                    client = new wrapPOPRFClient(id, pkSm)
-                    break
-            }
-        })
-
-        it('keygen', () => {
-            expect(toHex(skSm)).toBe(testVector.skSm)
-        })
-
-        const { vectors } = testVector
-
-        describe.each(vectors)('vec$#', (vi: (typeof vectors)[number]) => {
-            it('protocol', async () => {
-                // Creates a mock for randomBlinder method to
-                // inject the blind value given by the test vector.
-                for (const c of [OPRFClient, VOPRFClient, wrapPOPRFClient]) {
-                    let i = 0
-                    jest.spyOn(c.prototype, 'randomBlinder').mockImplementation(() => {
-                        const group = Oprf.getGroup(id)
-                        return Promise.resolve(group.desScalar(fromHexList(vi.Blind)[i++]))
-                    })
+                    case Oprf.Mode.POPRF:
+                        server = new wrapPOPRFServer(id, skSm)
+                        client = new wrapPOPRFClient(id, pkSm)
+                        break
                 }
+            })
 
-                if (testVector.mode === Oprf.Mode.POPRF) {
-                    const info = fromHex((vi as any).Info as string) // eslint-disable-line @typescript-eslint/no-explicit-any
-                    ;(server as wrapPOPRFServer).info = info
-                    ;(client as wrapPOPRFClient).info = info
-                }
+            it('keygen', () => {
+                expect(toHex(skSm)).toBe(testVector.skSm)
+            })
 
-                const input = fromHexList(vi.Input)
-                const [finData, evalReq] = await client.blind(input)
-                expect(toHexListClass(finData.blinds)).toEqual(vi.Blind)
-                expect(toHexListClass(evalReq.blinded)).toEqual(vi.BlindedElement)
+            const { vectors } = testVector
 
-                const ev = await server.blindEvaluate(evalReq)
-                expect(toHexListClass(ev.evaluated)).toEqual(vi.EvaluationElement)
+            describe.each(vectors)('vec$#', (vi: (typeof vectors)[number]) => {
+                it('protocol', async () => {
+                    // Creates a mock for randomBlinder method to
+                    // inject the blind value given by the test vector.
+                    for (const c of [OPRFClient, VOPRFClient, wrapPOPRFClient]) {
+                        let i = 0
+                        jest.spyOn(c.prototype, 'randomBlinder').mockImplementation(() => {
+                            const group = Oprf.getGroup(id)
+                            return Promise.resolve(group.desScalar(fromHexList(vi.Blind)[i++]))
+                        })
+                    }
 
-                const output = await client.finalize(finData, ev)
-                expect(toHexListUint8Array(output)).toEqual(vi.Output)
+                    if (testVector.mode === Oprf.Mode.POPRF) {
+                        const info = fromHex((vi as any).Info as string) // eslint-disable-line @typescript-eslint/no-explicit-any
+                        ;(server as wrapPOPRFServer).info = info
+                        ;(client as wrapPOPRFClient).info = info
+                    }
 
-                const serverCheckOutput = zip(input, output).every(
-                    async (inout) => await server.verifyFinalize(inout[0], inout[1])
-                )
-                expect(serverCheckOutput).toBe(true)
+                    const input = fromHexList(vi.Input)
+                    const [finData, evalReq] = await client.blind(input)
+                    expect(toHexListClass(finData.blinds)).toEqual(vi.Blind)
+                    expect(toHexListClass(evalReq.blinded)).toEqual(vi.BlindedElement)
+
+                    const ev = await server.blindEvaluate(evalReq)
+                    expect(toHexListClass(ev.evaluated)).toEqual(vi.EvaluationElement)
+
+                    const output = await client.finalize(finData, ev)
+                    expect(toHexListUint8Array(output)).toEqual(vi.Output)
+
+                    const serverCheckOutput = zip(input, output).every(
+                        async (inout) => await server.verifyFinalize(inout[0], inout[1])
+                    )
+                    expect(serverCheckOutput).toBe(true)
+                })
             })
         })
     })

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,15 @@
+{
+    "extends": ["./tsconfig.json"],
+    "compilerOptions": {
+        "module": "CommonJS",
+        "outDir": "lib/cjs"
+    },
+    "references": [
+        {
+            "path": "src/sjcl/tsconfig.cjs.json"
+        },
+        {
+            "path": "src/tsconfig.cjs.json"
+        }
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "rootDir": ".",
-        "outDir": "./lib"
+        "outDir": "./lib/esm"
     },
     "files": [],
     "include": [],


### PR DESCRIPTION
Continuing on with #26 
Also deals with #30 

#### Scripts 

| Test Type | All Groups | Specific Group (For performance while testing) |
|-----------|---------------|-------------|
| All Tests | `npm test` | `GROUP_CONS=noble npm test` |
| ESM Tests | `npm run test:esm` | `GROUP_CONS=noble npm run test:esm` |
| CJS Tests | `npm run test:cjs` | `GROUP_CONS=noble npm run test:cjs` |

#### Notes 

* The Oprf.Group member is [re]configured by a describeGroupTests helper that takes a `declare` function and uses describe.each 
  * The library itself does not honour the env variable.
* @noble/hashes and @noble/curves are listed as "optionalDependencies" (also "devDependencies" for tests) as not strictly required to use the library
* Use Group.fromID factory instead of Group `new` constructor (eye to short vs [ristretto](https://github.com/paulmillr/noble-curves/blob/cf17f7fe01a262396db1b5efdeaff1b5fb31d84a/src/ed25519.ts#L361)/[decaf448](https://github.com/paulmillr/noble-curves/blob/cf17f7fe01a262396db1b5efdeaff1b5fb31d84a/src/ed448.ts#L326C1-L326C1) etc)

