### PR TITLE
refactor: add @cloudflare/voprf-ts/facade and pass crypto as arg everywhere

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   testing:
-    name: Testing on Node v${{ matrix.node }}
+    name: Testing on Node v${{ matrix.node }} / CRYPTO_PROVIDER_ARG_REQUIRED=${{ matrix.crypto_arg_required }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 18]
+        node: [ 20, 18 ]
+        crypto_arg_required: [ true, false ]
     steps:
       - name: Checking out
         uses: actions/checkout@v3
@@ -28,14 +29,24 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
+      - name: Modify buildSettings.ts for testing
+        run: sed -i "s/CRYPTO_PROVIDER_ARG_REQUIRED = false/CRYPTO_PROVIDER_ARG_REQUIRED = ${{ matrix.crypto_arg_required }}/g" src/buildSettings.ts
+
       - name: Check lint
         run: npm run lint
 
       - name: Check build
         run: npm run build
 
+      - name: Check build others
+        if: matrix.crypto_arg_required == false
+        run: npm run build:others
+
       - name: Run NPM tests
         run: npm test
 
       - name: Check examples
-        run: npm run examples
+        if: matrix.crypto_arg_required == false
+        run: |
+          npm run examples
+          npm run examples:facade

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Finally, the client can produce the output[s] of the OPRF protocol using the ser
 const [output] = await client.finalize(finData, evaluation);
 ```
 
+### Facade API 
+
+See [examples](examples/facade/index.ts)
+
 ### Development
 
 | Task            | NPM scripts          |

--- a/bench/group.bench.ts
+++ b/bench/group.bench.ts
@@ -4,7 +4,7 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import Benchmark from 'benchmark'
-import { Oprf } from '../src/index.js'
+import { type CryptoProvider } from '@cloudflare/voprf-ts'
 
 function asyncFn(call: CallableFunction) {
     return {
@@ -16,13 +16,13 @@ function asyncFn(call: CallableFunction) {
     }
 }
 
-export async function benchGroup(bs: Benchmark.Suite) {
+export async function benchGroup(provider: CryptoProvider, bs: Benchmark.Suite) {
     const te = new TextEncoder()
     const msg = te.encode('msg')
     const dst = te.encode('dst')
 
-    for (const id of Oprf.Group.supportedGroups) {
-        const gg = Oprf.Group.fromID(id)
+    for (const id of provider.Group.supportedGroups) {
+        const gg = provider.Group.get(id)
         const k = await gg.randomScalar()
         const P = gg.mulGen(k)
         const Q = P.mul(k)

--- a/bench/testProviders.ts
+++ b/bench/testProviders.ts
@@ -1,0 +1,16 @@
+import { CryptoNoble } from '../src/cryptoNoble.js'
+import { CryptoSjcl } from '../src/cryptoSjcl.js'
+
+const allProviders = [CryptoNoble, CryptoSjcl]
+const providerMatch = process.env.CRYPTO_PROVIDER
+
+export function getCryptoProviders() {
+    const names = allProviders.map((p) => p.id)
+    const testProviders = allProviders.filter(
+        (provider) => !providerMatch || provider.id === providerMatch
+    )
+    if (testProviders.length === 0) {
+        throw new Error(`no CryptoProvider with name === ${providerMatch} among [${names}]`)
+    }
+    return testProviders
+}

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,8 +1,13 @@
 {
     "extends": "../tsconfig.json",
-    "include": [
-        "."
-    ],
+    "compilerOptions": {
+        "paths": {
+            "@cloudflare/voprf-ts": ["../src/index.js"],
+            "@cloudflare/voprf-ts/crypto-noble": ["../src/cryptoNoble.js"],
+            "@cloudflare/voprf-ts/facade": ["../src/facade/index.js"]
+        }
+    },
+    "include": ["."],
     "references": [
         {
             "path": ".."

--- a/examples/facade/index.ts
+++ b/examples/facade/index.ts
@@ -1,0 +1,165 @@
+import { CryptoNoble } from '@cloudflare/voprf-ts/crypto-noble'
+// You may want to do this when 3rd party dependencies use voprf-ts
+// import { Oprf as OprfCore } from '@cloudflare/voprf-ts'
+// OprfCore.Crypto = CryptoNoble
+
+import { webcrypto } from 'node:crypto'
+
+import { Oprf, type OprfApi, type SuiteID } from '@cloudflare/voprf-ts/facade'
+
+export async function facadeOprfExample(Oprf: OprfApi, suite: SuiteID = Oprf.Suite.P521_SHA512) {
+    // Setup: Create client and server.
+    const mode = Oprf.makeMode({
+        mode: Oprf.Mode.OPRF,
+        suite
+    })
+    const privateKey = await mode.keys.randomPrivate()
+
+    const server = mode.makeServer(privateKey)
+    const client = mode.makeClient()
+
+    // Client                                       Server
+    // ====================================================
+    // Step 1: The client prepares arbitrary input that will be evaluated by the
+    // server, the blinding method produces an evaluation request, and some
+    // finalization data to be used later. Then, the client sends the evaluation
+    // request to the server.
+    //
+    // Client
+    // blind, blindedElement = Blind(input)
+    const input = 'This is the client input'
+    const inputBytes = new TextEncoder().encode(input)
+    const [finData, evalReq] = await client.blind([inputBytes])
+    //             evalReq
+    //       ------------------>>
+    //                                              Server
+    // Step 2: Once the server received the evaluation request, it responds to
+    // the client with an evaluation.
+    //
+    //          evaluation = BlindEvaluate(evalReq, info*)
+    const evaluation = await server.blindEvaluate(evalReq)
+    // evaluation.proof <- does not have member
+
+    //            evaluation
+    //       <<------------------
+    //
+    // Client
+    // Step 3: Finally, the client can produce the output of the OPRF protocol
+    // using the server's evaluation and the finalization data from the first
+    // step. If the mode is verifiable, this step allows the client to check the
+    // proof that the server used the expected private key for the evaluation.
+    //
+    // output = Finalize(finData, evaluation, info*)
+    const [output] = await client.finalize(finData, evaluation)
+
+    // Step 4: redemption song!
+    const verified = await server.verifyFinalize(inputBytes, output)
+
+    console.log(`Example OPRF - SuiteID: ${mode.suite}`)
+    console.log(`CryptoProvider: ${mode.crypto.id}`)
+    console.log(`input  (${input.length} bytes): ${input}`)
+    console.log(`output (${output.length} bytes): ${Buffer.from(output).toString('hex')}`)
+    console.log(`verified: ${verified}\n`)
+}
+
+export async function facadePoprfExample(Oprf: OprfApi, suite: SuiteID = Oprf.Suite.P256_SHA256) {
+    // Setup: Create client and server.
+    const mode = Oprf.makeMode({
+        mode: Oprf.Mode.POPRF,
+        suite
+    })
+    const { privateKey, publicKey } = await mode.keys.generatePair()
+
+    const server = mode.makeServer(privateKey)
+    const client = mode.makeClient(publicKey)
+
+    // Client                                       Server
+    // ====================================================
+    // Step 1: The client prepares arbitrary input that will be evaluated by the
+    // server, the blinding method produces an evaluation request, and some
+    // finalization data to be used later. Then, the client sends the evaluation
+    // request to the server.
+
+    const input = 'This is the client input'
+    const info = 'Shared info between server and client'
+    const inputBytes = new TextEncoder().encode(input)
+    const infoBytes = new TextEncoder().encode(info)
+    const [finData, evalReq] = await client.blind([inputBytes])
+
+    // Step 2: Once the server received the evaluation request, it responds to
+    // the client with an evaluation.
+    const evaluation = await server.blindEvaluate(evalReq, infoBytes)
+
+    // Step 3: Finally, the client can produce the output of the OPRF protocol
+    // using the server's evaluation and the finalization data from the first
+    // step. If the mode is verifiable, this step allows the client to check the
+    // proof that the server used the expected private key for the evaluation.
+    const [output] = await client.finalize(finData, evaluation, infoBytes)
+
+    // Step 4: redemption song!
+    const verified = await server.verifyFinalize(inputBytes, output, infoBytes)
+
+    console.log(`Example POPRF - SuiteID: ${mode.suite}`)
+    console.log(`CryptoProvider: ${mode.crypto.id}`)
+    console.log(`input  (${input.length} bytes): ${input}`)
+    console.log(`output (${output.length} bytes): ${Buffer.from(output).toString('hex')}`)
+    console.log(`info   (${info.length} bytes): ${info}`)
+    console.log(`verified: ${verified}\n`)
+}
+
+export async function facadeVoprfExample(Oprf: OprfApi, suite: SuiteID = Oprf.Suite.P384_SHA384) {
+    // Setup: Create client and server.
+    const mode = Oprf.makeMode({
+        mode: Oprf.Mode.VOPRF,
+        suite
+    })
+    const { privateKey, publicKey } = await mode.keys.generatePair()
+
+    const server = mode.makeServer(privateKey)
+    const client = mode.makeClient(publicKey)
+
+    // Client                                       Server
+    // ====================================================
+    // Step 1: The client prepares arbitrary input that will be evaluated by the
+    // server, the blinding method produces an evaluation request, and some
+    // finalization data to be used later. Then, the client sends the evaluation
+    // request to the server.
+
+    const input = 'This is the client input'
+    const inputBytes = new TextEncoder().encode(input)
+    const [finData, evalReq] = await client.blind([inputBytes])
+
+    // Step 2: Once the server received the evaluation request, it responds to
+    // the client with an evaluation.
+    const evaluation = await server.blindEvaluate(evalReq)
+
+    // Step 3: Finally, the client can produce the output of the OPRF protocol
+    // using the server's evaluation and the finalization data from the first
+    // step. If the mode is verifiable, this step allows the client to check the
+    // proof that the server used the expected private key for the evaluation.
+    const [output] = await client.finalize(finData, evaluation)
+
+    // Step 4: redemption song!
+    const verified = await server.verifyFinalize(inputBytes, output)
+
+    console.log(`Example VOPRF - SuiteID: ${mode.suite}`)
+    console.log(`CryptoProvider: ${mode.crypto.id}`)
+    console.log(`input  (${input.length} bytes): ${input}`)
+    console.log(`output (${output.length} bytes): ${Buffer.from(output).toString('hex')}\n`)
+    console.log(`verified: ${verified}\n`)
+}
+
+async function main() {
+    if (typeof crypto === 'undefined') {
+        Object.assign(global, { crypto: webcrypto })
+    }
+    await facadeOprfExample(Oprf)
+    await facadeVoprfExample(Oprf)
+
+    // This suite requires the noble crypto provider as sjcl doesn't support
+    // ristretto.
+    const OprfNoble = Oprf.withConfig({ crypto: CryptoNoble })
+    await facadePoprfExample(OprfNoble, Oprf.Suite.RISTRETTO255_SHA512)
+}
+
+main().catch(console.error)

--- a/examples/oprf.ts
+++ b/examples/oprf.ts
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { OPRFClient, OPRFServer, Oprf, randomPrivateKey } from '../src/index.js'
+import { OPRFClient, OPRFServer, Oprf, randomPrivateKey } from '@cloudflare/voprf-ts'
 
 // Example: OPRF mode with the P521-SHA512 suite.
 export async function oprfExample() {

--- a/examples/poprf.ts
+++ b/examples/poprf.ts
@@ -9,7 +9,7 @@ import {
     POPRFServer,
     generatePublicKey,
     randomPrivateKey
-} from '../src/index.js'
+} from '@cloudflare/voprf-ts'
 
 // Example: POPRF mode with the P256_SHA256 suite.
 export async function poprfExample() {

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,8 +1,13 @@
 {
     "extends": "../tsconfig.json",
-    "include": [
-        "."
-    ],
+    "compilerOptions": {
+        "paths": {
+            "@cloudflare/voprf-ts": ["../src/index.js"],
+            "@cloudflare/voprf-ts/crypto-noble": ["../src/cryptoNoble.js"],
+            "@cloudflare/voprf-ts/facade": ["../src/facade/index.js"]
+        }
+    },
+    "include": ["."],
     "references": [
         {
             "path": ".."

--- a/examples/voprf.ts
+++ b/examples/voprf.ts
@@ -9,7 +9,7 @@ import {
     VOPRFServer,
     generatePublicKey,
     randomPrivateKey
-} from '../src/index.js'
+} from '@cloudflare/voprf-ts'
 
 // Example: VOPRF mode with the P384-SHA384 suite.
 export async function voprfExample() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "@cloudflare/voprf-ts",
             "version": "0.21.2",
+            "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "@noble/curves": "1.2.0",
@@ -25,6 +26,7 @@
                 "jest": "29.7.0",
                 "prettier": "3.0.3",
                 "sjcl": "1.0.8",
+                "tsx": "^3.13.0",
                 "typescript": "5.2.2"
             },
             "engines": {
@@ -657,9 +659,9 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+            "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.22.13",
@@ -705,6 +707,358 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -2738,6 +3092,43 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.18.20",
+                "@esbuild/android-arm64": "0.18.20",
+                "@esbuild/android-x64": "0.18.20",
+                "@esbuild/darwin-arm64": "0.18.20",
+                "@esbuild/darwin-x64": "0.18.20",
+                "@esbuild/freebsd-arm64": "0.18.20",
+                "@esbuild/freebsd-x64": "0.18.20",
+                "@esbuild/linux-arm": "0.18.20",
+                "@esbuild/linux-arm64": "0.18.20",
+                "@esbuild/linux-ia32": "0.18.20",
+                "@esbuild/linux-loong64": "0.18.20",
+                "@esbuild/linux-mips64el": "0.18.20",
+                "@esbuild/linux-ppc64": "0.18.20",
+                "@esbuild/linux-riscv64": "0.18.20",
+                "@esbuild/linux-s390x": "0.18.20",
+                "@esbuild/linux-x64": "0.18.20",
+                "@esbuild/netbsd-x64": "0.18.20",
+                "@esbuild/openbsd-x64": "0.18.20",
+                "@esbuild/sunos-x64": "0.18.20",
+                "@esbuild/win32-arm64": "0.18.20",
+                "@esbuild/win32-ia32": "0.18.20",
+                "@esbuild/win32-x64": "0.18.20"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3280,6 +3671,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+            "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+            "dev": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/glob": {
@@ -4949,6 +5352,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/resolve.exports": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -5365,6 +5777,33 @@
             },
             "peerDependencies": {
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+            }
+        },
+        "node_modules/tsx": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.13.0.tgz",
+            "integrity": "sha512-rjmRpTu3as/5fjNq/kOkOtihgLxuIz6pbKdj9xwP4J5jOLkBxw/rjN5ANw+KyrrOXV5uB7HC8+SrrSJxT65y+A==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "~0.18.20",
+                "get-tsconfig": "^4.7.2",
+                "source-map-support": "^0.5.21"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -1,81 +1,91 @@
 {
-    "name": "@cloudflare/voprf-ts",
-    "version": "0.21.2",
-    "description": "voprf-ts: A TypeScript Library for Oblivious Pseudorandom Functions (OPRF)",
-    "author": "Armando Faz <armfazh@cloudflare.com>",
-    "maintainers": [
-        "Armando Faz <armfazh@cloudflare.com>"
-    ],
-    "contributors": [
-        "Nicholas Dudfield <ndudfield@gmail.com>"
-    ],
-    "license": "BSD-3-Clause",
-    "private": false,
-    "main": "./lib/cjs/src/index.js",
-    "module": "./lib/esm/src/index.js",
-    "types": "./lib/esm/src/index.d.ts",
-    "exports": {
-        ".": {
-            "default": "./lib/cjs/src/index.js",
-            "require": "./lib/cjs/src/index.js",
-            "import": "./lib/esm/src/index.js"
-        },
-        "./crypto-noble": {
-            "require": "./lib/cjs/src/cryptoNoble.js",
-            "import": "./lib/esm/src/cryptoNoble.js"
-        }
+  "name": "@cloudflare/voprf-ts",
+  "version": "0.21.2",
+  "description": "voprf-ts: A TypeScript Library for Oblivious Pseudorandom Functions (OPRF)",
+  "author": "Armando Faz <armfazh@cloudflare.com>",
+  "maintainers": [
+    "Armando Faz <armfazh@cloudflare.com>"
+  ],
+  "contributors": [
+    "Nicholas Dudfield <ndudfield@gmail.com>"
+  ],
+  "license": "BSD-3-Clause",
+  "private": false,
+  "main": "./lib/cjs/src/index.js",
+  "module": "./lib/esm/src/index.js",
+  "types": "./lib/esm/src/index.d.ts",
+  "exports": {
+    ".": {
+      "default": "./lib/cjs/src/index.js",
+      "require": "./lib/cjs/src/index.js",
+      "import": "./lib/esm/src/index.js"
     },
-    "files": [
-        "lib/**/src/**/!(*.tsbuildinfo)",
-        "webcrypto.md"
-    ],
-    "keywords": [
-        "oprf",
-        "voprf",
-        "poprf",
-        "crypto",
-        "cryptography"
-    ],
-    "homepage": "https://github.com/cloudflare/voprf-ts#readme",
-    "repository": "github:cloudflare/voprf-ts",
-    "engines": {
-        "node": ">=18"
+    "./crypto-noble": {
+      "default": "./lib/cjs/src/cryptoNoble.js",
+      "require": "./lib/cjs/src/cryptoNoble.js",
+      "import": "./lib/esm/src/cryptoNoble.js"
     },
-    "devDependencies": {
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/benchmark": "2.1.3",
-        "@types/jest": "29.5.5",
-        "@typescript-eslint/eslint-plugin": "6.7.3",
-        "@typescript-eslint/parser": "6.7.3",
-        "benchmark": "2.1.4",
-        "eslint": "8.50.0",
-        "eslint-config-prettier": "9.0.0",
-        "eslint-plugin-jest": "27.4.0",
-        "eslint-plugin-jest-formatting": "3.1.0",
-        "eslint-plugin-prettier": "5.0.0",
-        "eslint-plugin-security": "1.7.1",
-        "jest": "29.7.0",
-        "prettier": "3.0.3",
-        "sjcl": "1.0.8",
-        "typescript": "5.2.2"
-    },
-    "scripts": {
-        "prepack": "tsc -b . tsconfig.cjs.json",
-        "prepare": "tsc -b . tsconfig.cjs.json",
-        "build": "tsc -b . tsconfig.cjs.json",
-        "clean": "tsc -b --clean . test ./tsconfig.cjs.json test/tsconfig.cjs.json bench examples",
-        "test": "npm run test:esm && npm run test:cjs",
-        "test:esm": "npm run test:build && node --experimental-vm-modules node_modules/.bin/jest --ci --selectProjects esm --coverageDirectory coverage/esm",
-        "test:cjs": "npm run test:build && node node_modules/.bin/jest --ci --selectProjects cjs --coverageDirectory coverage/cjs",
-        "test:build": "tsc -b test test/tsconfig.cjs.json",
-        "examples": "tsc -b examples && node ./lib/esm/examples/index.js",
-        "lint": "eslint .",
-        "bench": "tsc -b bench && node ./lib/esm/bench/index.js",
-        "format": "prettier './(src|test|bench|examples)/**/!(*.d).ts' --write"
-    },
-    "optionalDependencies": {
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2"
+    "./facade": {
+      "default": "./lib/cjs/src/facade/index.js",
+      "require": "./lib/cjs/src/facade/index.js",
+      "import": "./lib/esm/src/facade/index.js"
     }
+  },
+  "files": [
+    "lib/**/src/**/!(*.tsbuildinfo)",
+    "webcrypto.md"
+  ],
+  "keywords": [
+    "oprf",
+    "voprf",
+    "poprf",
+    "crypto",
+    "cryptography"
+  ],
+  "homepage": "https://github.com/cloudflare/voprf-ts#readme",
+  "repository": "github:cloudflare/voprf-ts",
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@noble/curves": "1.2.0",
+    "@noble/hashes": "1.3.2",
+    "@types/benchmark": "2.1.3",
+    "@types/jest": "29.5.5",
+    "@typescript-eslint/eslint-plugin": "6.7.3",
+    "@typescript-eslint/parser": "6.7.3",
+    "benchmark": "2.1.4",
+    "eslint": "8.50.0",
+    "eslint-config-prettier": "9.0.0",
+    "eslint-plugin-jest": "27.4.0",
+    "eslint-plugin-jest-formatting": "3.1.0",
+    "eslint-plugin-prettier": "5.0.0",
+    "eslint-plugin-security": "1.7.1",
+    "jest": "29.7.0",
+    "prettier": "3.0.3",
+    "sjcl": "1.0.8",
+    "tsx": "^3.13.0",
+    "typescript": "5.2.2"
+  },
+  "scripts": {
+    "prepack": "tsc -b . tsconfig.cjs.json",
+    "prepare": "tsc -b . tsconfig.cjs.json",
+    "build": "tsc -b . tsconfig.cjs.json",
+    "build:others": "tsc -b bench examples",
+    "clean": "tsc -b --clean . test ./tsconfig.cjs.json test/tsconfig.cjs.json bench examples",
+    "test": "npm run test:esm && npm run test:cjs",
+    "test:esm": "npm run test:build && node --experimental-vm-modules node_modules/.bin/jest --ci --selectProjects esm --coverageDirectory coverage/esm",
+    "test:cjs": "npm run test:build && node node_modules/.bin/jest --ci --selectProjects cjs --coverageDirectory coverage/cjs",
+    "test:build": "tsc -b test test/tsconfig.cjs.json",
+    "examples": "npm run build && tsx examples/index.ts",
+    "examples:facade": "npm run build && tsx examples/facade/index.ts",
+    "lint": "eslint .",
+    "bench": "npm run build && tsx bench/index.ts",
+    "format": "prettier './(src|test|bench|examples)/**/!(*.d).ts' --write",
+    "format:json": "prettier './**/*.json' '!./node_modules/**' '!./package-lock.json' '!./test/testdata/allVectors_v20.json' --write"
+  },
+  "optionalDependencies": {
+    "@noble/curves": "1.2.0",
+    "@noble/hashes": "1.3.2"
+  }
 }

--- a/src/buildSettings.ts
+++ b/src/buildSettings.ts
@@ -1,0 +1,18 @@
+// This file can be easily written over in CI
+import { CryptoSjcl } from './cryptoSjcl.js'
+
+// See CryptoProviderArg used as ...rest type pervasively
+// We can set this to `true` to check that the internal code and
+// tests are properly passing around the provider object everywhere.
+// We can set it to `false` to not require the arg and let it
+// default to `DEFAULT_CRYPTO_PROVIDER`
+export const CRYPTO_PROVIDER_ARG_REQUIRED = false
+
+// Of course, this means that using the api with a non default provider
+// is not very nice, but it does allow the facade api to avoid the
+// use of a global, and potentially allow the use of multiple providers
+// in a single process, picking and choosing a provider for group support.
+// You can use setCryptoProvider if you want to use the non-facade api with a
+// non-default provider and not need to pass everything around.
+// Single provider per process limitations apply.
+export const DEFAULT_CRYPTO_PROVIDER = CryptoSjcl

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,22 @@
+export const MODE = {
+    OPRF: 0,
+    VOPRF: 1,
+    POPRF: 2
+} as const
+
+export const SUITE = {
+    P256_SHA256: 'P256-SHA256',
+    P384_SHA384: 'P384-SHA384',
+    P521_SHA512: 'P521-SHA512',
+    RISTRETTO255_SHA512: 'ristretto255-SHA512',
+    DECAF448_SHAKE256: 'decaf448-SHAKE256'
+} as const
+
+export const LABELS = {
+    Version: 'OPRFV1-',
+    FinalizeDST: 'Finalize',
+    HashToGroupDST: 'HashToGroup-',
+    HashToScalarDST: 'HashToScalar-',
+    DeriveKeyPairDST: 'DeriveKeyPair',
+    InfoLabel: 'Info'
+} as const

--- a/src/cryptoImpl.ts
+++ b/src/cryptoImpl.ts
@@ -1,0 +1,39 @@
+import { getOprfParams, type SuiteID } from './oprf.js'
+import type { CryptoProvider } from './cryptoTypes.js'
+import { CRYPTO_PROVIDER_ARG_REQUIRED, DEFAULT_CRYPTO_PROVIDER } from './buildSettings.js'
+import type { GroupID } from './groupTypes.js'
+
+const REQUIRED = CRYPTO_PROVIDER_ARG_REQUIRED
+let configured = DEFAULT_CRYPTO_PROVIDER
+
+type OptionalArg = [cryptoProvider?: CryptoProvider]
+type RequiredArg = [CryptoProvider]
+
+export type CryptoProviderArg = typeof REQUIRED extends true ? RequiredArg : OptionalArg
+
+export function getCrypto(arg: CryptoProviderArg) {
+    const [provider] = arg as OptionalArg
+    if (!provider && REQUIRED) {
+        throw new Error(`Undefined crypto arg`)
+    }
+
+    return provider ?? configured
+}
+
+export function getGroup(groupID: GroupID, arg: CryptoProviderArg) {
+    const provider = getCrypto(arg)
+    return provider.Group.get(groupID)
+}
+
+export function getSuiteGroup(suite: SuiteID, arg: CryptoProviderArg) {
+    return getGroup(getOprfParams(suite)[1], arg)
+}
+
+// This way the `old` api can be used
+export function setCryptoProvider(provider: CryptoProvider) {
+    configured = provider
+}
+
+export function getCryptoProvider() {
+    return configured
+}

--- a/src/cryptoNoble.ts
+++ b/src/cryptoNoble.ts
@@ -8,6 +8,7 @@ import type { CryptoProvider, HashID } from './cryptoTypes.js'
 import { hashSync } from './noble/hashes.js'
 
 export const CryptoNoble: CryptoProvider = {
+    id: 'noble',
     Group: GroupNb,
     hash(hashID: HashID, input: Uint8Array): Promise<Uint8Array> {
         return Promise.resolve(hashSync(hashID, input))

--- a/src/cryptoSjcl.ts
+++ b/src/cryptoSjcl.ts
@@ -7,6 +7,7 @@ import type { CryptoProvider, HashID } from './cryptoTypes.js'
 import { GroupConsSjcl } from './groupSjcl.js'
 
 export const CryptoSjcl: CryptoProvider = {
+    id: 'sjcl',
     Group: GroupConsSjcl,
     async hash(hashID: HashID, input: Uint8Array): Promise<Uint8Array> {
         return new Uint8Array(await crypto.subtle.digest(hashID, input))

--- a/src/cryptoTypes.ts
+++ b/src/cryptoTypes.ts
@@ -8,6 +8,7 @@ import type { GroupCons } from './groupTypes.js'
 export type HashID = 'SHA-512' | 'SHA-256' | 'SHA-384' | 'SHAKE256'
 
 export interface CryptoProvider {
+    id: string
     Group: GroupCons
     hash(hashID: HashID, input: Uint8Array): Promise<Uint8Array>
 }

--- a/src/facade/impl/ClientImpl.ts
+++ b/src/facade/impl/ClientImpl.ts
@@ -1,0 +1,57 @@
+import type { Client, FinalizeData as FacadeFinalizeData } from '../types.js'
+import { OPRFClient, VOPRFClient, POPRFClient } from '../../client.js'
+import { MODE } from '../../consts.js'
+import { OprfBaseImpl } from './OprfBaseImpl.js'
+import { FinalizeData, EvaluationRequest } from '../../oprf.js'
+
+export class ClientImpl extends OprfBaseImpl implements Client {
+    spyHandle: Client['spyHandle']
+    blind: Client['blind']
+    finalize: Client['finalize']
+
+    constructor(
+        publicKey: Uint8Array | undefined,
+        ...args: ConstructorParameters<typeof OprfBaseImpl>
+    ) {
+        super(...args)
+        let wrapped: OPRFClient | VOPRFClient | POPRFClient
+        if (this.mode !== MODE.OPRF && !publicKey) {
+            throw new Error(`public key must be set for VOPRF|POPRF modes`)
+        } else {
+            publicKey = publicKey!
+        }
+
+        switch (this.mode) {
+            case MODE.OPRF:
+                wrapped = new OPRFClient(this.suite, this.crypto)
+                break
+            case MODE.POPRF:
+                wrapped = new POPRFClient(this.suite, publicKey, this.crypto)
+                break
+            case MODE.VOPRF:
+                wrapped = new VOPRFClient(this.suite, publicKey, this.crypto)
+                break
+            default:
+                throw new Error(`Unsupported mode: ${this.mode}`)
+        }
+        this.blind = async (inputs: Uint8Array[]) => {
+            const [finData, evalReq] = await wrapped.blind(inputs)
+            return [finData, this.codec.encodeEvaluationRequest(evalReq)]
+        }
+        this.finalize = (finData, evaluation, ...info) => {
+            return wrapped.finalize(
+                this.mapFinalizationData(finData),
+                this.codec.decodeEvaluation({ mode: this.mode, ...evaluation }),
+                ...info
+            )
+        }
+        this.spyHandle = { blinds: wrapped }
+    }
+
+    private mapFinalizationData(fac: FacadeFinalizeData): FinalizeData {
+        if (fac instanceof FinalizeData) {
+            return fac
+        }
+        return new FinalizeData(fac.inputs, fac.blinds, new EvaluationRequest(fac.evalReq.blinded))
+    }
+}

--- a/src/facade/impl/Codec.ts
+++ b/src/facade/impl/Codec.ts
@@ -1,0 +1,62 @@
+import type {
+    BaseEvaluation as FacadeEvaluationBase,
+    VerifiableEvaluation as FacadeVerifiableEvaluation,
+    Serialized,
+    EvaluationRequest as FacadeEvaluationRequest,
+    HasSerialize
+} from '../types.js'
+import type { Group, Elt, Scalar } from '../../groupTypes.js'
+import type { CryptoProvider } from '../../cryptoTypes.js'
+import { DLEQProof } from '../../dleq.js'
+import { Evaluation, EvaluationRequest } from '../../oprf.js'
+
+export type FacadeEvaluation = FacadeEvaluationBase & Partial<FacadeVerifiableEvaluation>
+
+export class Codec {
+    constructor(
+        private group: Group,
+        private crypto: CryptoProvider
+    ) {}
+
+    decodeElts(evaluated: Array<Serialized<Elt>>): Elt[] {
+        return evaluated.map(this.group.desElt.bind(this.group))
+    }
+
+    decodeScalars(evaluated: Array<Serialized<Scalar>>): Scalar[] {
+        return evaluated.map(this.group.desScalar.bind(this.group))
+    }
+
+    encodeArray(array: HasSerialize<Uint8Array>[]): Uint8Array[] {
+        return array.map((e) => e.serialize())
+    }
+
+    decodeProof(proof: Uint8Array) {
+        return DLEQProof.deserialize(this.group.id, proof, this.crypto)
+    }
+
+    encodeEvaluation(lib: Evaluation): FacadeEvaluation {
+        return {
+            proof: lib.proof ? lib.proof.serialize() : undefined,
+            mode: lib.mode,
+            evaluated: this.encodeArray(lib.evaluated)
+        }
+    }
+
+    encodeEvaluationRequest(evalRequest: EvaluationRequest): FacadeEvaluationRequest {
+        return {
+            blinded: this.encodeArray(evalRequest.blinded)
+        }
+    }
+
+    decodeEvaluation(fac: FacadeEvaluation): Evaluation {
+        return new Evaluation(
+            fac.mode,
+            this.decodeElts(fac.evaluated),
+            fac.proof ? this.decodeProof(fac.proof) : undefined
+        )
+    }
+
+    decodeEvaluationRequest(fac: FacadeEvaluationRequest) {
+        return new EvaluationRequest(this.decodeElts(fac.blinded))
+    }
+}

--- a/src/facade/impl/KeyManagerImpl.ts
+++ b/src/facade/impl/KeyManagerImpl.ts
@@ -1,0 +1,47 @@
+import { OprfBaseImpl } from './OprfBaseImpl.js'
+import type { KeySizes, KeyPair, KeyManager } from '../types.js'
+import {
+    getKeySizes,
+    validatePrivateKey,
+    validatePublicKey,
+    randomPrivateKey,
+    derivePrivateKey,
+    generatePublicKey,
+    generateKeyPair,
+    deriveKeyPair
+} from '../../keys.js'
+
+export class KeyManagerImpl extends OprfBaseImpl implements KeyManager {
+    sizes(): KeySizes {
+        const internal = getKeySizes(this.suite, this.crypto)
+        return { publicKey: internal.Npk, privateKey: internal.Nsk }
+    }
+
+    validatePrivate(privateKey: Uint8Array): boolean {
+        return validatePrivateKey(this.suite, privateKey, this.crypto)
+    }
+
+    validatePublic(publicKey: Uint8Array): boolean {
+        return validatePublicKey(this.suite, publicKey, this.crypto)
+    }
+
+    randomPrivate(): Promise<Uint8Array> {
+        return randomPrivateKey(this.suite, this.crypto)
+    }
+
+    derivePrivate(seed: Uint8Array, info: Uint8Array): Promise<Uint8Array> {
+        return derivePrivateKey(this.mode, this.suite, seed, info, this.crypto)
+    }
+
+    generatePublic(privateKey: Uint8Array): Uint8Array {
+        return generatePublicKey(this.suite, privateKey, this.crypto)
+    }
+
+    generatePair(): Promise<KeyPair> {
+        return generateKeyPair(this.suite, this.crypto)
+    }
+
+    derivePair(seed: Uint8Array, info: Uint8Array): Promise<KeyPair> {
+        return deriveKeyPair(this.mode, this.suite, seed, info, this.crypto)
+    }
+}

--- a/src/facade/impl/ModeImpl.ts
+++ b/src/facade/impl/ModeImpl.ts
@@ -1,0 +1,52 @@
+import type { Mode, ModeID, SuiteID, Server, Client, KeyManager, ModeParams } from '../types.js'
+import type { Group } from '../../groupTypes.js'
+import type { CryptoProvider } from '../../cryptoTypes.js'
+import { ServerImpl } from './ServerImpl.js'
+import { ClientImpl } from './ClientImpl.js'
+import { KeyManagerImpl } from './KeyManagerImpl.js'
+import { getOprfParams } from '../../oprf.js'
+
+export class ModeImpl implements Mode {
+    keys: KeyManager
+    params: ModeParams
+
+    constructor(
+        public mode: ModeID,
+        public suite: SuiteID,
+        public group: Group,
+        public crypto: CryptoProvider
+    ) {
+        this.keys = new KeyManagerImpl(...this.getBaseArgs())
+        this.params = this.getParams()
+    }
+
+    private getParams() {
+        const [suite, group, hash, size] = getOprfParams(this.suite)
+        const scalar = this.group.scalarSize()
+        const elt = this.group.eltSize()
+        return {
+            mode: this.mode,
+            suite,
+            group,
+            hash,
+            sizes: {
+                elt: elt,
+                output: size,
+                proof: scalar * 2,
+                scalar
+            }
+        }
+    }
+
+    makeServer(privateKey: Uint8Array): Server {
+        return new ServerImpl(privateKey, ...this.getBaseArgs())
+    }
+
+    makeClient(publicKey?: Uint8Array): Client {
+        return new ClientImpl(publicKey, ...this.getBaseArgs())
+    }
+
+    private getBaseArgs() {
+        return [this.mode, this.suite, this.crypto, this.group] as const
+    }
+}

--- a/src/facade/impl/OprfApiImpl.ts
+++ b/src/facade/impl/OprfApiImpl.ts
@@ -1,0 +1,26 @@
+import type { OprfApi, ModeID, MakeModeParams, Mode } from '../types.js'
+import type { CryptoProvider } from '../../cryptoTypes.js'
+import { SUITE, MODE } from '../../consts.js'
+import { getOprfParams } from '../../oprf.js'
+import { ModeImpl } from './ModeImpl.js'
+import { getCryptoProvider } from '../../cryptoImpl.js'
+
+export class OprfApiImpl implements OprfApi {
+    constructor(private _crypto?: CryptoProvider) {}
+
+    get crypto() {
+        return this._crypto ?? getCryptoProvider()
+    }
+
+    Suite = SUITE
+    Mode = MODE
+
+    withConfig(config: { crypto: CryptoProvider }): OprfApi {
+        return new OprfApiImpl(config.crypto)
+    }
+
+    makeMode<M extends ModeID>(params: MakeModeParams<M>): Mode<M> {
+        const group = this.crypto.Group.get(getOprfParams(params.suite)[1])
+        return new ModeImpl(params.mode, params.suite, group, this.crypto) as Mode as Mode<M>
+    }
+}

--- a/src/facade/impl/OprfBaseImpl.ts
+++ b/src/facade/impl/OprfBaseImpl.ts
@@ -1,0 +1,15 @@
+import type { ModeID, SuiteID } from '../types.js'
+import { Codec } from './Codec.js'
+import type { CryptoProvider } from '../../cryptoTypes.js'
+import type { Group } from '../../groupTypes.js'
+
+export class OprfBaseImpl {
+    protected codec = new Codec(this.group, this.crypto)
+
+    constructor(
+        public mode: ModeID,
+        public suite: SuiteID,
+        public crypto: CryptoProvider,
+        public group: Group
+    ) {}
+}

--- a/src/facade/impl/ServerImpl.ts
+++ b/src/facade/impl/ServerImpl.ts
@@ -1,0 +1,39 @@
+import type { Server } from '../types.js'
+import { OPRFServer, VOPRFServer, POPRFServer } from '../../server.js'
+import { MODE } from '../../consts.js'
+import { OprfBaseImpl } from './OprfBaseImpl.js'
+
+export class ServerImpl extends OprfBaseImpl implements Server {
+    verifyFinalize: Server['verifyFinalize']
+    blindEvaluate: Server['blindEvaluate']
+    spyHandle: Server['spyHandle']
+
+    constructor(privateKey: Uint8Array, ...args: ConstructorParameters<typeof OprfBaseImpl>) {
+        super(...args)
+        let wrapped: OPRFServer | VOPRFServer | POPRFServer
+        switch (this.mode) {
+            case MODE.OPRF:
+                wrapped = new OPRFServer(this.suite, privateKey, this.crypto)
+                break
+            case MODE.POPRF:
+                wrapped = new POPRFServer(this.suite, privateKey, this.crypto)
+                break
+            case MODE.VOPRF:
+                wrapped = new VOPRFServer(this.suite, privateKey, this.crypto)
+                break
+            default:
+                throw new Error(`Unsupported mode: ${this.mode}`)
+        }
+        this.spyHandle = {
+            dleqProver: wrapped['prover']
+        }
+        this.verifyFinalize = wrapped.verifyFinalize.bind(wrapped)
+        this.blindEvaluate = async (req, ...info) => {
+            const internal = await wrapped.blindEvaluate(
+                this.codec.decodeEvaluationRequest(req),
+                ...info
+            )
+            return this.codec.encodeEvaluation(internal)
+        }
+    }
+}

--- a/src/facade/index.ts
+++ b/src/facade/index.ts
@@ -1,0 +1,6 @@
+import { OprfApiImpl } from './impl/OprfApiImpl.js'
+
+export const Oprf = new OprfApiImpl(undefined)
+export * from './types.js'
+export * from '../cryptoTypes.js'
+export * from '../groupTypes.js'

--- a/src/facade/types.ts
+++ b/src/facade/types.ts
@@ -1,0 +1,147 @@
+import type { CryptoProvider, HashID } from '../cryptoTypes.js'
+import type { Elt, Group, Scalar, GroupID } from '../groupTypes.js'
+import type { MODE, SUITE } from '../consts.js'
+
+export type SuiteID = (typeof SUITE)[keyof typeof SUITE]
+export type ModeOprf = typeof MODE.OPRF
+export type ModePoprf = typeof MODE.POPRF
+export type ModeVoprf = typeof MODE.VOPRF
+export type ModeID = ModeOprf | ModeVoprf | ModePoprf
+
+export type HasSerialize<T> = { serialize(): T }
+export type Serialized<T extends HasSerialize<unknown>> = T extends HasSerialize<infer R>
+    ? R
+    : never
+
+export interface Modal<M extends ModeID> {
+    readonly mode: M
+    readonly suite: SuiteID
+}
+
+export interface UsesCrypto {
+    readonly crypto: CryptoProvider
+    readonly group: Group
+}
+
+export type DLEQProof = { c: Scalar; s: Scalar; serialize(): Uint8Array }
+// OPRF protocol only specifies encodings for these elements
+export type OPRFElement = Elt | Scalar | DLEQProof
+
+// So we only encode elements/bytes, and leave packet encoding to application layer
+export interface EvaluationRequest {
+    readonly blinded: Array<Serialized<Elt>>
+}
+
+export interface BaseEvaluation {
+    readonly mode: ModeID
+    readonly evaluated: Array<Serialized<Elt>>
+}
+
+export interface VerifiableEvaluation extends BaseEvaluation {
+    readonly proof: Serialized<DLEQProof>
+}
+
+export interface FinalizeData {
+    readonly inputs: Array<Uint8Array>
+    readonly blinds: Array<Scalar>
+    readonly evalReq: {
+        readonly blinded: Array<Elt> // Keep wet elements
+    }
+}
+
+export interface KeyPair {
+    readonly privateKey: Uint8Array
+    readonly publicKey: Uint8Array
+}
+
+export interface KeySizes {
+    readonly privateKey: number
+    readonly publicKey: number
+}
+
+export interface KeyManager extends Modal<ModeID>, UsesCrypto {
+    sizes(): KeySizes
+
+    validatePrivate(privateKey: Uint8Array): boolean
+
+    validatePublic(publicKey: Uint8Array): boolean
+
+    randomPrivate(): Promise<Uint8Array>
+
+    derivePrivate(seed: Uint8Array, info: Uint8Array): Promise<Uint8Array>
+
+    generatePublic(privateKey: Uint8Array): Uint8Array
+
+    generatePair(): Promise<KeyPair>
+
+    derivePair(seed: Uint8Array, info: Uint8Array): Promise<KeyPair>
+}
+
+// Using the tuple labels `info?:` gives us a nice IDE experience
+type Info<M> = M extends ModePoprf ? [info?: Uint8Array] : []
+type Evaluation<M extends ModeID> = M extends ModeOprf ? BaseEvaluation : VerifiableEvaluation
+type PublicKey<M extends ModeID = ModeID> = M extends ModeOprf ? [] : [publicKey: Uint8Array]
+
+export interface OprfBase<M extends ModeID> extends Modal<M>, UsesCrypto {}
+
+export interface Client<M extends ModeID = ModeID> extends OprfBase<M> {
+    spyHandle: {
+        blinds: {
+            randomBlinder(): Promise<Scalar>
+        }
+    }
+
+    blind(inputs: Uint8Array[]): Promise<[FinalizeData, EvaluationRequest]>
+
+    finalize(
+        finData: FinalizeData,
+        evaluation: Omit<Evaluation<M>, 'mode'>,
+        ...info: Info<M>
+    ): Promise<Array<Uint8Array>>
+}
+
+export interface Server<M extends ModeID = ModeID> extends OprfBase<M> {
+    spyHandle: {
+        dleqProver: {
+            randomScalar(): Promise<Scalar>
+        }
+    }
+
+    blindEvaluate(req: EvaluationRequest, ...info: Info<M>): Promise<Evaluation<M>>
+
+    verifyFinalize(input: Uint8Array, output: Uint8Array, ...info: Info<M>): Promise<boolean>
+}
+
+export interface ModeParams<M extends ModeID = ModeID> extends Modal<M> {
+    group: GroupID
+    hash: HashID
+    sizes: {
+        elt: number
+        scalar: number
+        proof: number
+        output: number
+    }
+}
+
+export interface Mode<M extends ModeID = ModeID> extends Modal<M>, UsesCrypto {
+    params: ModeParams<M>
+
+    readonly keys: KeyManager
+
+    makeServer(privateKey: Uint8Array): Server<M>
+
+    makeClient(...publicKey: PublicKey<M>): Client<M>
+}
+
+export interface MakeModeParams<M extends ModeID> extends Modal<M> {}
+
+export interface OprfApi {
+    readonly Suite: typeof SUITE
+    readonly Mode: typeof MODE
+
+    readonly crypto: CryptoProvider
+
+    withConfig(config: { crypto: CryptoProvider }): OprfApi
+
+    makeMode<M extends ModeID>(params: MakeModeParams<M>): Mode<M>
+}

--- a/src/groupTypes.ts
+++ b/src/groupTypes.ts
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-export const Groups = {
+export const GROUP = {
     // P256_XMD:SHA-256_SSWU_RO_
     P256: 'P-256',
     // P384_XMD:SHA-384_SSWU_RO_
@@ -16,7 +16,7 @@ export const Groups = {
     DECAF448: 'decaf448'
 } as const
 
-export type GroupID = (typeof Groups)[keyof typeof Groups]
+export type GroupID = (typeof GROUP)[keyof typeof GROUP]
 
 export function errBadGroup(X: string) {
     return new Error(`group: bad group name ${X}.`)
@@ -98,6 +98,8 @@ export interface Group extends SerializationHelpers {
 }
 
 export interface GroupCons {
-    fromID(id: GroupID): Group
+    get(id: GroupID): Group
     supportedGroups: Array<GroupID>
 }
+
+export type GroupCache = Partial<Record<GroupID, Group>>

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -3,37 +3,51 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { type ModeID, type SuiteID, Oprf } from './oprf.js'
+import { type ModeID, Oprf, type SuiteID } from './oprf.js'
 import { joinAll, toU16LenPrefix } from './util.js'
 import { type Scalar } from './groupTypes.js'
+import { type CryptoProviderArg, getSuiteGroup } from './cryptoImpl.js'
 
-export function getKeySizes(id: SuiteID): { Nsk: number; Npk: number } {
-    const gg = Oprf.getGroup(id)
+export function getKeySizes(id: SuiteID, ...arg: CryptoProviderArg): { Nsk: number; Npk: number } {
+    const gg = getSuiteGroup(id, arg)
     return { Nsk: gg.scalarSize(), Npk: gg.eltSize(true) }
 }
 
-export function validatePrivateKey(id: SuiteID, privateKey: Uint8Array): boolean {
+export function validatePrivateKey(
+    id: SuiteID,
+    privateKey: Uint8Array,
+    ...arg: CryptoProviderArg
+): boolean {
     try {
-        const s = Oprf.getGroup(id).desScalar(privateKey)
+        const gg = getSuiteGroup(id, arg)
+        const s = gg.desScalar(privateKey)
         return !s.isZero()
     } catch (_) {
         return false
     }
 }
 
-export function validatePublicKey(id: SuiteID, publicKey: Uint8Array): boolean {
+export function validatePublicKey(
+    id: SuiteID,
+    publicKey: Uint8Array,
+    ...arg: CryptoProviderArg
+): boolean {
     try {
-        const P = Oprf.getGroup(id).desElt(publicKey)
+        const gg = getSuiteGroup(id, arg)
+        const P = gg.desElt(publicKey)
         return !P.isIdentity()
     } catch (_) {
         return false
     }
 }
 
-export async function randomPrivateKey(id: SuiteID): Promise<Uint8Array> {
-    const gg = Oprf.getGroup(id)
+export async function randomPrivateKey(
+    id: SuiteID,
+    ...arg: CryptoProviderArg
+): Promise<Uint8Array> {
     let priv: Scalar
     do {
+        const gg = getSuiteGroup(id, arg)
         priv = await gg.randomScalar()
     } while (priv.isZero())
 
@@ -44,9 +58,10 @@ export async function derivePrivateKey(
     mode: ModeID,
     id: SuiteID,
     seed: Uint8Array,
-    info: Uint8Array
+    info: Uint8Array,
+    ...arg: CryptoProviderArg
 ): Promise<Uint8Array> {
-    const gg = Oprf.getGroup(id)
+    const gg = getSuiteGroup(id, arg)
     const deriveInput = joinAll([seed, ...toU16LenPrefix(info)])
     let counter = 0
     let priv: Scalar
@@ -63,18 +78,23 @@ export async function derivePrivateKey(
     return priv.serialize()
 }
 
-export function generatePublicKey(id: SuiteID, privateKey: Uint8Array): Uint8Array {
-    const gg = Oprf.getGroup(id)
+export function generatePublicKey(
+    id: SuiteID,
+    privateKey: Uint8Array,
+    ...arg: CryptoProviderArg
+): Uint8Array {
+    const gg = getSuiteGroup(id, arg)
     const priv = gg.desScalar(privateKey)
     const pub = gg.mulGen(priv)
     return pub.serialize(true)
 }
 
 export async function generateKeyPair(
-    id: SuiteID
+    id: SuiteID,
+    ...arg: CryptoProviderArg
 ): Promise<{ privateKey: Uint8Array; publicKey: Uint8Array }> {
-    const privateKey = await randomPrivateKey(id)
-    const publicKey = generatePublicKey(id, privateKey)
+    const privateKey = await randomPrivateKey(id, ...arg)
+    const publicKey = generatePublicKey(id, privateKey, ...arg)
     return { privateKey, publicKey }
 }
 
@@ -82,9 +102,10 @@ export async function deriveKeyPair(
     mode: ModeID,
     id: SuiteID,
     seed: Uint8Array,
-    info: Uint8Array
+    info: Uint8Array,
+    ...arg: CryptoProviderArg
 ): Promise<{ privateKey: Uint8Array; publicKey: Uint8Array }> {
-    const privateKey = await derivePrivateKey(mode, id, seed, info)
-    const publicKey = generatePublicKey(id, privateKey)
+    const privateKey = await derivePrivateKey(mode, id, seed, info, ...arg)
+    const publicKey = generatePublicKey(id, privateKey, ...arg)
     return { privateKey, publicKey }
 }

--- a/src/noble/edwards.ts
+++ b/src/noble/edwards.ts
@@ -17,7 +17,7 @@ export interface MakeEdParamsParams {
     hash: CHash
 }
 
-export function makeEdParams({
+export function edwardsCurve({
     curve,
     hashID,
     scalarHash,

--- a/src/noble/element.ts
+++ b/src/noble/element.ts
@@ -5,9 +5,10 @@
 
 import type { ProjPointType } from '@noble/curves/abstract/weierstrass'
 import type { Elt } from '../groupTypes.js'
-import { ScalarNb } from './scalar.js'
 import type { Point, PointConstructor } from './types.js'
 import type { GroupNb } from './group.js'
+import type { ScalarNb } from './scalar.js'
+
 import { compat, errDeserialization } from '../util.js'
 
 export class EltNb implements Elt {

--- a/src/noble/group.ts
+++ b/src/noble/group.ts
@@ -5,7 +5,13 @@
 
 import { bytesToNumberBE, bytesToNumberLE } from '@noble/curves/abstract/utils'
 
-import { type Deserializer, type Group, type GroupID, Groups } from '../groupTypes.js'
+import {
+    type Deserializer,
+    GROUP,
+    type Group,
+    type GroupCache,
+    type GroupID
+} from '../groupTypes.js'
 import type { GroupParams } from './types.js'
 import { ScalarNb } from './scalar.js'
 import { EltNb } from './element.js'
@@ -13,15 +19,17 @@ import { getParams } from './params.js'
 
 export class GroupNb implements Group {
     static readonly supportedGroups: GroupID[] = [
-        Groups.RISTRETTO255,
-        Groups.DECAF448,
-        Groups.P256,
-        Groups.P384,
-        Groups.P521
+        GROUP.RISTRETTO255,
+        GROUP.DECAF448,
+        GROUP.P256,
+        GROUP.P384,
+        GROUP.P521
     ]
 
-    static fromID(gid: GroupID) {
-        return new this(gid)
+    static readonly #cache: GroupCache = {}
+
+    static get(gid: GroupID) {
+        return (this.#cache[`${gid}`] ??= new this(gid))
     }
 
     public readonly params: GroupParams

--- a/src/noble/params.ts
+++ b/src/noble/params.ts
@@ -2,43 +2,43 @@
 // Copyright (c) 2021 Cloudflare, Inc.
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
-
 import * as p256 from '@noble/curves/p256'
 import * as p384 from '@noble/curves/p384'
 import * as p521 from '@noble/curves/p521'
 import * as ed25519 from '@noble/curves/ed25519'
-import { hashToRistretto255 } from '@noble/curves/ed25519'
 import * as ed448 from '@noble/curves/ed448'
+import { hashToRistretto255 } from '@noble/curves/ed25519'
 import { hashToDecaf448 } from '@noble/curves/ed448'
-
-import { errBadGroup, type GroupID, Groups } from '../groupTypes.js'
-import type { GroupParams } from './types.js'
-import { makeShortParams } from './short.js'
-import { makeEdParams } from './edwards.js'
-import { shake256_512 } from './hashes.js'
 import { sha512 } from '@noble/hashes/sha512'
 
+import { errBadGroup, GROUP, type GroupID } from '../groupTypes.js'
+import type { GroupParams } from './types.js'
+
+import { shortCurve } from './short.js'
+import { edwardsCurve } from './edwards.js'
+import { shake256_512 } from './hashes.js'
+
 const GROUPS: Record<GroupID, GroupParams> = {
-    [Groups.P256]: makeShortParams({
+    [GROUP.P256]: shortCurve({
         curve: p256.p256,
         hashID: 'SHA-256',
         elementHash: p256.hashToCurve,
         securityBits: 128
     }),
-    [Groups.P384]: makeShortParams({
+    [GROUP.P384]: shortCurve({
         curve: p384.p384,
         hashID: 'SHA-384',
         elementHash: p384.hashToCurve,
         securityBits: 192
     }),
-    [Groups.P521]: makeShortParams({
+    [GROUP.P521]: shortCurve({
         curve: p521.p521,
         hashID: 'SHA-512',
         elementHash: p521.hashToCurve,
         securityBits: 256
     }),
 
-    [Groups.RISTRETTO255]: makeEdParams({
+    [GROUP.RISTRETTO255]: edwardsCurve({
         curve: ed25519.ed25519,
         hashID: 'SHA-512',
         scalarHash: { type: 'xmd' },
@@ -48,7 +48,7 @@ const GROUPS: Record<GroupID, GroupParams> = {
         },
         hash: sha512
     }),
-    [Groups.DECAF448]: makeEdParams({
+    [GROUP.DECAF448]: edwardsCurve({
         curve: ed448.ed448,
         hashID: 'SHAKE256',
         scalarHash: { type: 'xof', k: 448 },
@@ -61,7 +61,6 @@ const GROUPS: Record<GroupID, GroupParams> = {
 }
 
 export function getParams(gid: GroupID) {
-    if (!Object.values(Groups).includes(gid)) throw errBadGroup(gid)
-    // eslint-disable-next-line security/detect-object-injection
-    return GROUPS[gid]
+    if (!Object.values(GROUP).includes(gid)) throw errBadGroup(gid)
+    return GROUPS[`${gid}`]
 }

--- a/src/noble/scalar.ts
+++ b/src/noble/scalar.ts
@@ -13,9 +13,7 @@ import type { Scalar } from '../groupTypes.js'
 import { checkSize, compat, errDeserialization } from '../util.js'
 
 import type { PrimeField } from './types.js'
-
 import type { GroupNb } from './group.js'
-
 export class ScalarNb implements Scalar {
     private readonly field: PrimeField
     public readonly k: bigint

--- a/src/noble/short.ts
+++ b/src/noble/short.ts
@@ -15,7 +15,7 @@ export interface MakeShortParamsArgs {
     securityBits: number
 }
 
-export function makeShortParams({
+export function shortCurve({
     hashID,
     curve,
     elementHash,

--- a/src/sjcl/index.js
+++ b/src/sjcl/index.js
@@ -3599,12 +3599,12 @@ sjcl.codec.arrayBuffer = {
   }
 };
 
-if(typeof module !== 'undefined' && module.exports){
-  module.exports = sjcl;
-}
-if (typeof define === "function") {
-    define([], function () {
-        return sjcl;
-    });
-}
+// if(typeof module !== 'undefined' && module.exports){
+//   module.exports = sjcl;
+// }
+// if (typeof define === "function") {
+//     define([], function () {
+//         return sjcl;
+//     });
+// }
 export default sjcl;

--- a/test/describeCryptoTests.ts
+++ b/test/describeCryptoTests.ts
@@ -1,0 +1,30 @@
+import { CryptoNoble } from '../src/cryptoNoble.js'
+import {
+    type CryptoProvider,
+    getOprfParams,
+    getSupportedSuites,
+    type GroupID
+} from '../src/index.js'
+import { CryptoSjcl } from '../src/cryptoSjcl.js'
+
+const cryptoProviderMatch = process.env.CRYPTO_PROVIDER
+const allProviders = [CryptoNoble, CryptoSjcl]
+export const testProviders = allProviders
+    .filter((provider) => !cryptoProviderMatch || provider.id === cryptoProviderMatch)
+    .map((p) => [p.id, p] as const)
+
+export function describeCryptoTests(
+    declare: (args: {
+        provider: CryptoProvider
+        supportedSuites: Array<ReturnType<typeof getOprfParams>>
+        supportedGroups: GroupID[]
+    }) => void
+) {
+    describe.each(testProviders)(`CryptoProvider({id: '%s'})`, (_, provider) => {
+        declare({
+            provider: provider,
+            supportedSuites: getSupportedSuites(provider.Group).map(getOprfParams),
+            supportedGroups: provider.Group.supportedGroups
+        })
+    })
+}

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -3,12 +3,12 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { describeGroupTests } from './describeGroupTests.js'
+import { describeCryptoTests } from './describeCryptoTests.js'
 import { serdesEquals } from './util.js'
 
-describeGroupTests((Group) => {
-    describe.each(Group.supportedGroups)('%s', (id) => {
-        const gg = Group.fromID(id)
+describeCryptoTests(({ provider, supportedGroups }) => {
+    describe.each(supportedGroups)('%s', (id) => {
+        const gg = provider.Group.get(id)
 
         it('serdeElement', async () => {
             const P = gg.mulGen(await gg.randomScalar())

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -7,18 +7,17 @@ import {
     deriveKeyPair,
     generateKeyPair,
     getKeySizes,
-    getSupportedSuites,
     Oprf,
     validatePrivateKey,
     validatePublicKey
 } from '../src/index.js'
-import { describeGroupTests } from './describeGroupTests.js'
+import { describeCryptoTests } from './describeCryptoTests.js'
 
-describeGroupTests((g) => {
-    describe.each(getSupportedSuites(g))('oprf-keys', (id) => {
+describeCryptoTests(({ provider, supportedSuites }) => {
+    describe.each(supportedSuites)('oprf-keys', (id, groupID) => {
         describe(`${id}`, () => {
-            const { Nsk, Npk } = getKeySizes(id)
-            const gg = Oprf.getGroup(id)
+            const { Nsk, Npk } = getKeySizes(id, provider)
+            const gg = provider.Group.get(groupID)
 
             it('getKeySizes', () => {
                 expect(Nsk).toBe(gg.scalarSize())
@@ -27,40 +26,40 @@ describeGroupTests((g) => {
 
             it('zeroPrivateKey', () => {
                 const zeroKeyBytes = new Uint8Array(Nsk)
-                const ret = validatePrivateKey(id, zeroKeyBytes)
+                const ret = validatePrivateKey(id, zeroKeyBytes, provider)
                 expect(ret).toBe(false)
             })
 
             it('badPrivateKey', () => {
                 const bad = new Uint8Array(100)
                 bad.fill(0xff)
-                const ret = validatePrivateKey(id, bad)
+                const ret = validatePrivateKey(id, bad, provider)
                 expect(ret).toBe(false)
             })
 
             it('onesPrivateKey', () => {
                 const onesKeyBytes = new Uint8Array(Nsk).fill(0xff)
-                const ret = validatePrivateKey(id, onesKeyBytes)
+                const ret = validatePrivateKey(id, onesKeyBytes, provider)
                 expect(ret).toBe(false)
             })
 
             it('identityPublicKey', () => {
                 const identityKeyBytes = gg.identity().serialize()
-                const ret = validatePublicKey(id, identityKeyBytes)
+                const ret = validatePublicKey(id, identityKeyBytes, provider)
                 expect(ret).toBe(false)
             })
 
             it('onesPublicKey', () => {
                 const onesKeyBytes = new Uint8Array(Npk).fill(0xff)
-                const ret = validatePublicKey(id, onesKeyBytes)
+                const ret = validatePublicKey(id, onesKeyBytes, provider)
                 expect(ret).toBe(false)
             })
 
             it('generateKeyPair', async () => {
                 for (let i = 0; i < 64; i++) {
-                    const keys = await generateKeyPair(id) // eslint-disable-line no-await-in-loop
-                    const sk = validatePrivateKey(id, keys.privateKey)
-                    const pk = validatePublicKey(id, keys.publicKey)
+                    const keys = await generateKeyPair(id, provider) // eslint-disable-line no-await-in-loop
+                    const sk = validatePrivateKey(id, keys.privateKey, provider)
+                    const pk = validatePublicKey(id, keys.publicKey, provider)
                     expect(sk).toBe(true)
                     expect(pk).toBe(true)
                 }
@@ -70,9 +69,9 @@ describeGroupTests((g) => {
                 const info = new TextEncoder().encode('info used for derivation')
                 for (let i = 0; i < 64; i++) {
                     const seed = crypto.getRandomValues(new Uint8Array(Nsk))
-                    const keys = await deriveKeyPair(Oprf.Mode.OPRF, id, seed, info) // eslint-disable-line no-await-in-loop
-                    const sk = validatePrivateKey(id, keys.privateKey)
-                    const pk = validatePublicKey(id, keys.publicKey)
+                    const keys = await deriveKeyPair(Oprf.Mode.OPRF, id, seed, info, provider) // eslint-disable-line no-await-in-loop
+                    const sk = validatePrivateKey(id, keys.privateKey, provider)
+                    const pk = validatePublicKey(id, keys.publicKey, provider)
                     expect(sk).toBe(true)
                     expect(pk).toBe(true)
                 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -3,18 +3,20 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
+import type { CryptoProviderArg } from '../src/cryptoImpl.js'
+
 export function serdeClass<
     U,
     K extends {
-        deserialize: (u: U, b: Uint8Array) => T
+        deserialize: (u: U, b: Uint8Array, ...arg: CryptoProviderArg) => T
     },
     T extends {
         serialize: () => Uint8Array
         isEqual: (t: T) => boolean
     }
->(k: K, t: T, u: U): boolean {
+>(k: K, t: T, u: U, ...arg: CryptoProviderArg): boolean {
     const ser = t.serialize()
-    const deser = k.deserialize(u, ser)
+    const deser = k.deserialize(u, ser, ...arg)
     return t.isEqual(deser)
 }
 


### PR DESCRIPTION
Supercedes #44

### Pass Around Crypto As Arg Everywhere

1. Oprf.Group -> hash(...) doesn't belong here! and WebCrypto doesn't support shake256
2. Oprf.Crypto -> circular dependencies!  
3. CryptoImpl.provider ->  better, but ick, a global?
4. Explicit optional provider passing (crypto?: CryptoProvider) -> tests failing, where??
5. Required (crypto: CryptoProvider)-> fixed, but damn that's verbose and breaks api
6. --> !!CryptoProvider via...Rest syntax -> nice, can configure Rest as [CryptoProvider] or [CryptoProvider?]!! <---
7. But why? -> Can make sure passing around the provider everywhere
8. But why? ->  Oprf.withConfig({provider: CryptoNoble) and old Oprf work in same process
9. So what? -> In any case ... 

Toggle [this setting](https://github.com/cloudflare/voprf-ts/pull/49/files#diff-939fbbde9cf1b0707741b13dfd69e906bf2ca839475bb966da809b0bc4420c4aR9) here and try the `npm run examples` in both modes
Fails to build when it's required - [added to ci](https://github.com/cloudflare/voprf-ts/pull/49/files#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR18)

### @cloudflare/voprf-ts/facade, backwards compat impl of #46

See [examples](https://github.com/sublimator/voprf-ts/blob/nd-switch-flipping-2023-10-10/examples/facade/index.ts#L3-L6)

### Named imports for examples

Uses tsx to execute examples/bench which supports runtime compilerOptions.paths to provide more readily modifiable examples.  

### Breaking changes

Minimum changes needed for: https://github.com/cloudflare/privacypass-ts/pull/15
Also see: [Port to facade](https://github.com/armfazh/privacypass-ts/compare/implVoprfToken2...sublimator:privacypass-ts:nd-facade-charade-2023-10-15?expand=1)

```typescript
diff --git a/src/priv_verif_token.ts b/src/priv_verif_token.ts
index 08c95c9..8809078 100644
--- a/src/priv_verif_token.ts
+++ b/src/priv_verif_token.ts
@@ -9,7 +9,6 @@ import {
     VOPRFClient,
     VOPRFServer,
     generateKeyPair,
-    type DLEQParams,
     type Group,
     type SuiteID,
     type HashID,
@@ -31,7 +30,6 @@ export interface VOPRFExtraParams {
     Ns: number;
     Nk: number;
     hash: HashID;
-    dleqParams: DLEQParams;
 }
 
 const VOPRF_SUITE = Oprf.Suite.P384_SHA384;
@@ -44,12 +42,6 @@ const VOPRF_EXTRA_PARAMS: VOPRFExtraParams = {
     Ns: VOPRF_GROUP.scalarSize(),
     Nk: Oprf.getOprfSize(VOPRF_SUITE),
     hash: VOPRF_HASH,
-    dleqParams: {
-        gg: VOPRF_GROUP,
-        hashID: VOPRF_HASH,
-        hash: Oprf.Crypto.hash,
-        dst: '',
-    },
 } as const;
 
 // Token Type Entry Update:
@@ -82,6 +74,7 @@ export class TokenRequest2 {
     //   } TokenRequest;
 
     tokenType: number;
+
     constructor(
         public readonly truncatedTokenKeyId: number,
         public readonly blindedMsg: Uint8Array,
@@ -257,7 +250,7 @@ export class Client2 {
             throw new Error('no token request was created yet');
         }
 
-        const proof = DLEQProof.deserialize(VOPRF.dleqParams, tokRes.evaluateProof);
+        const proof = DLEQProof.deserialize(VOPRF.group.id, tokRes.evaluateProof);
         const evaluateMsg = VOPRF.group.desElt(tokRes.evaluateMsg);
         const evaluation = new Evaluation(Oprf.Mode.VOPRF, [evaluateMsg], proof);
         const [authenticator] = await this.finData.vClient.finalize(
```

### TODO

- [ ] Full document Security.md that summarizes the current status of both back-ends (@armfazh)