### PR TITLE
Fixing import type declarations.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
     "root": true,
     "parserOptions": {
         "ecmaVersion": 2020,
-        "sourceType": "module"
+        "sourceType": "module",
+        "project": true
     },
     "extends": [
         "eslint:recommended",
@@ -76,15 +77,15 @@
                     "error",
                     "never"
                 ],
-                "@typescript-eslint/no-namespace": [
-                    "warn"
-                ],
+                "@typescript-eslint/no-namespace": "warn",
                 "@typescript-eslint/no-unused-vars": [
                     "error",
                     {
                         "argsIgnorePattern": "^_"
                     }
-                ]
+                ],
+                "@typescript-eslint/consistent-type-imports": "error",
+                "@typescript-eslint/consistent-type-exports": "error"
             }
         }
     ]

--- a/bench/group.bench.ts
+++ b/bench/group.bench.ts
@@ -3,8 +3,8 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import Benchmark from 'benchmark'
-import { type CryptoProvider } from '@cloudflare/voprf-ts'
+import type Benchmark from 'benchmark'
+import type { CryptoProvider } from '../src/cryptoTypes.js'
 
 function asyncFn(call: CallableFunction) {
     return {

--- a/bench/index.ts
+++ b/bench/index.ts
@@ -10,7 +10,7 @@ import { benchGroup } from './group.bench.js'
 import { benchOPRF } from './oprf.bench.js'
 import { getCryptoProviders } from './testProviders.js'
 
-import { type CryptoProvider } from '../src/index.js'
+import type { CryptoProvider } from '../src/cryptoTypes.js'
 
 if (typeof crypto === 'undefined') {
     Object.assign(global, { crypto: webcrypto })

--- a/bench/oprf.bench.ts
+++ b/bench/oprf.bench.ts
@@ -17,7 +17,7 @@ import {
     randomPrivateKey
 } from '../src/index.js'
 
-import Benchmark from 'benchmark'
+import type Benchmark from 'benchmark'
 
 function asyncFn(call: CallableFunction) {
     return {

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,12 +1,5 @@
 {
     "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "paths": {
-            "@cloudflare/voprf-ts": ["../src/index.js"],
-            "@cloudflare/voprf-ts/crypto-noble": ["../src/cryptoNoble.js"],
-            "@cloudflare/voprf-ts/facade": ["../src/facade/index.js"]
-        }
-    },
     "include": ["."],
     "references": [
         {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,14 +4,8 @@
 // at https://opensource.org/licenses/BSD-3-Clause
 
 import type { Elt, Scalar } from './groupTypes.js'
-import {
-    Evaluation,
-    EvaluationRequest,
-    FinalizeData,
-    type ModeID,
-    Oprf,
-    type SuiteID
-} from './oprf.js'
+import type { Evaluation, ModeID, SuiteID } from './oprf.js'
+import { EvaluationRequest, FinalizeData, Oprf } from './oprf.js'
 
 import { zip } from './util.js'
 import type { CryptoProviderArg } from './cryptoImpl.js'

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -5,7 +5,7 @@
 
 import { type ModeID, Oprf, type SuiteID } from './oprf.js'
 import { joinAll, toU16LenPrefix } from './util.js'
-import { type Scalar } from './groupTypes.js'
+import type { Scalar } from './groupTypes.js'
 import { type CryptoProviderArg, getSuiteGroup } from './cryptoImpl.js'
 
 export function getKeySizes(id: SuiteID, ...arg: CryptoProviderArg): { Nsk: number; Npk: number } {

--- a/src/noble/hashes.ts
+++ b/src/noble/hashes.ts
@@ -5,8 +5,10 @@
 
 import { sha256 } from '@noble/hashes/sha256'
 import { sha384, sha512 } from '@noble/hashes/sha512'
-import { type CHash, Hash, wrapConstructor } from '@noble/hashes/utils'
-import { Keccak, shake256 } from '@noble/hashes/sha3'
+import type { Hash, CHash } from '@noble/hashes/utils'
+import { wrapConstructor } from '@noble/hashes/utils'
+import type { Keccak } from '@noble/hashes/sha3'
+import { shake256 } from '@noble/hashes/sha3'
 import type { HashID } from '../cryptoTypes.js'
 
 export const shake256_512 = wrapConstructor<Hash<Keccak>>(() => shake256.create({ dkLen: 64 }))

--- a/src/noble/types.ts
+++ b/src/noble/types.ts
@@ -3,11 +3,11 @@
 // Licensed under the BSD-3-Clause license found in the LICENSE file or
 // at https://opensource.org/licenses/BSD-3-Clause
 
-import { Field } from '@noble/curves/abstract/modular'
+import type { Field } from '@noble/curves/abstract/modular'
 import type { CHash } from '@noble/hashes/utils'
-import * as p256 from '@noble/curves/p256'
-import * as ed25519 from '@noble/curves/ed25519'
-import * as ed448 from '@noble/curves/ed448'
+import type * as p256 from '@noble/curves/p256'
+import type * as ed25519 from '@noble/curves/ed25519'
+import type * as ed448 from '@noble/curves/ed448'
 import type { Hex } from '@noble/curves/abstract/utils'
 
 import type { HashID } from '../cryptoTypes.js'

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,8 @@
 
 import { DLEQProver } from './dleq.js'
 import type { Elt, Scalar } from './groupTypes.js'
-import { Evaluation, EvaluationRequest, type ModeID, Oprf, type SuiteID } from './oprf.js'
+import type { EvaluationRequest, ModeID, SuiteID } from './oprf.js'
+import { Evaluation, Oprf } from './oprf.js'
 import { ctEqual, zip } from './util.js'
 import type { CryptoProviderArg } from './cryptoImpl.js'
 


### PR DESCRIPTION
Fixing import type declarations.
As of v5.0, Typescript with [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) flag enabled produces different code for singleton type imports.

![image](https://github.com/cloudflare/voprf-ts/assets/10335519/d6374dc2-7e26-414d-9e73-0654cc979936)


Also added a linter option that enforces this subtlety.